### PR TITLE
[GRDM-54345] Playwright実行エラーの修正

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -414,7 +414,7 @@ jobs:
     - name: Install Playwright
       run: |
         # Install Playwright browsers with OS dependencies
-        npx playwright install --with-deps chromium
+        playwright install --with-deps chromium
 
     - name: Prepare test configuration
       working-directory: e2e-tests


### PR DESCRIPTION
E2Eテストで発生していた「Executable doesn't exist」エラーを修正しました。

npx playwrightコマンドをplaywrightコマンドに修正し、Pythonパッケージと一致するバージョンのブラウザがインストールされるようにしました。