### PR TITLE
[GRDM-54829] e-Radテスト有効化とROR API v2対応の動作確認

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -543,7 +543,7 @@ jobs:
         skip_admin: ${{ matrix.test-group.skip_admin }}
         skip_login: ${{ matrix.test-group.skip_login || false }}
         enable_1gb_file_upload: false
-        skip_erad_completion_test: true
+        skip_erad_completion_test: false
         
         # Storage configurations (empty for CI)
         storages_oauth: []


### PR DESCRIPTION
## Purpose

ROR API v2対応に関連して、e-Rad自動補完テストを有効化します。(フラグの有効化)

なお、このPull Requestで有効化されるテストは、 https://github.com/RCOSDP/RDM-osf.io/pull/625 を実施することで成功するようになります。そのため、 Custom Test Configuration によりブランチを使ってテストをすることを指示しています。

## Changes

- e-Rad自動補完テストをサンプルデータで有効化

## Ticket

GRDM-54829

## Custom Test Configuration
<!-- Leave empty to use default settings. Specify custom settings to test with specific versions or fixes. -->
- RDM_REPOSITORY: yacchin1205/RDM2-osf.io
- RDM_BRANCH: feature/ror-v2
- OSF_IMAGE: 
- EMBER_IMAGE: 
- CAS_IMAGE: 
- MFR_IMAGE: 
- WB_IMAGE: