### PR TITLE
ユーザー機能テストの各種METADATA機能におけるフィールドを表示するためのスクロール対応

### DIFF
--- a/テスト手順-Metadataアドオン-複数メタデータの一括設定.ipynb
+++ b/テスト手順-Metadataアドオン-複数メタデータの一括設定.ipynb
@@ -19734,7 +19734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "id": "6037f58d",
    "metadata": {
     "deletable": true,
@@ -20031,7 +20031,6 @@
     "        print(name)\n",
     "        element = page.locator(f'//h3[text() = \"ファイルメタデータの編集\"]/../../..//label[text() = \"{name}\"]/../..')\n",
     "        await element.scroll_into_view_if_needed()\n",
-    "        await page.evaluate(\"document.querySelector('.modal-body').scrollBy(0, 80)\")\n",
     "        if isinstance(value, dict):\n",
     "            for key in value.keys():\n",
     "                table = ''\n",
@@ -20942,7 +20941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "id": "c0c6ac2e",
    "metadata": {
     "deletable": true,
@@ -21316,7 +21315,6 @@
     "        print(name)\n",
     "        element = page.locator(f'//h3[text() = \"ファイルメタデータの編集\"]/../../..//label[text() = \"{name}\"]/../..')\n",
     "        await element.scroll_into_view_if_needed()\n",
-    "        await page.evaluate(\"document.querySelector('.modal-body').scrollBy(0, 80)\")\n",
     "        if isinstance(value, dict):\n",
     "            for key in value.keys():\n",
     "                table = ''\n",
@@ -24244,7 +24242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": null,
    "id": "e7a65147",
    "metadata": {
     "deletable": true,
@@ -24586,7 +24584,6 @@
     "        print(name)\n",
     "        element = page.locator(f'//h3[text() = \"ファイルメタデータの編集\"]/../../..//label[text() = \"{name}\"]/../..')\n",
     "        await element.scroll_into_view_if_needed()\n",
-    "        await page.evaluate(\"document.querySelector('.modal-body').scrollBy(0, 80)\")\n",
     "        if isinstance(value, dict):\n",
     "            for key in value.keys():\n",
     "                table = ''\n",
@@ -25540,7 +25537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "id": "b50d8298",
    "metadata": {
     "deletable": true,
@@ -25897,7 +25894,6 @@
     "        print(name)\n",
     "        element = page.locator(f'//h3[text() = \"ファイルメタデータの編集\"]/../../..//label[text() = \"{name}\"]/../..')\n",
     "        await element.scroll_into_view_if_needed()\n",
-    "        await page.evaluate(\"document.querySelector('.modal-body').scrollBy(0, 80)\")\n",
     "        if isinstance(value, dict):\n",
     "            for key in value.keys():\n",
     "                table = ''\n",
@@ -42526,7 +42522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": null,
    "id": "f6c5018f",
    "metadata": {
     "deletable": true,
@@ -42814,7 +42810,6 @@
     "        print(name)\n",
     "        element = page.locator(f'//h3[text() = \"ファイルメタデータの編集\"]/../../..//label[text() = \"{name}\"]/../..')\n",
     "        await element.scroll_into_view_if_needed()\n",
-    "        await page.evaluate(\"document.querySelector('.modal-body').scrollBy(0, 110)\")\n",
     "        if isinstance(value, dict):\n",
     "            for key in value.keys():\n",
     "                table = ''\n",
@@ -43749,7 +43744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": null,
    "id": "bafb8821",
    "metadata": {
     "deletable": true,
@@ -44038,7 +44033,6 @@
     "        print(name)\n",
     "        element = page.locator(f'//h3[text() = \"ファイルメタデータの編集\"]/../../..//label[text() = \"{name}\"]/../..')\n",
     "        await element.scroll_into_view_if_needed()\n",
-    "        await page.evaluate(\"document.querySelector('.modal-body').scrollBy(0, 110)\")\n",
     "        if isinstance(value, dict):\n",
     "            for key in value.keys():\n",
     "                table = ''\n",
@@ -44616,7 +44610,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "3.11.5",
    "language": "python",
    "name": "python3"
   },
@@ -44626,7 +44620,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.11.5"
   },
   "lc_notebook_meme": {
    "current": "6b03238a-0430-11ef-b901-9ee4ca18f90f",


### PR DESCRIPTION
## Purpose
ユーザー機能テストの各種METADATA機能におけるフィールドを表示するためのスクロールを追加します。
## Changes
`テスト手順-Metadataアドオン-複数メタデータの一括設定.ipynb` のNo.53、56、65、68、110、113において、METADATA画面の先頭付近の一部フィールドのみが表示される状態となっていました。
そのため、METADATA画面上のすべてのフィールドを表示できるよう、`await element.scroll_into_view_if_needed()` を追加しました。
## Ticket

## Custom Test Configuration
- RDM_REPOSITORY: RCOSDP/RDM-osf.io
- RDM_BRANCH: develop
- OSF_IMAGE:
- EMBER_IMAGE:
- CAS_IMAGE:
- MFR_IMAGE:
- WB_IMAGE:
- EXCLUDE_NOTEBOOKS: