### PR TITLE
BinderHub機能のテストにおける停止中のBinderHubの設定を修正

### DIFF
--- a/テスト手順-BinderHub-BinderHubアドオン-停止中のBinderHubアドオン.ipynb
+++ b/テスト手順-BinderHub-BinderHubアドオン-停止中のBinderHubアドオン.ipynb
@@ -24,7 +24,17 @@
     "\n",
     "project_name = None\n",
     "\n",
-    "halted_binderhub_url = 'https://example.com'"
+    "halted_hub = dict(\n",
+    "    binderhub_url=\"https://example.com\",\n",
+    "    binderhub_oauth_client_id=\"AAAA\",\n",
+    "    binderhub_oauth_client_secret=\"BBBB\",\n",
+    "    jupyterhub_url=\"https://example.net\",\n",
+    "    jupyterhub_oauth_client_id=\"XXXX\",\n",
+    "    jupyterhub_oauth_client_secret=\"YYYY\",\n",
+    "    jupyterhub_admin_api_token=\"YYYY\",\n",
+    "    jupyterhub_logout_url=\"https://example.net/hub/logout\",\n",
+    "    jupyterhub_max_servers=\"3\",\n",
+    ")"
    ]
   },
   {
@@ -227,6 +237,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0402f77c",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "Discovery Serviceページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79c391f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    open_idp_list = page.locator('//*[@id = \"dropdown_img\"]')\n",
+    "    launch_button = page.locator('//*[@data-test-binderhub-launch]')\n",
+    "    await expect(open_idp_list.or_(launch_button)).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "    if await open_idp_list.is_visible():\n",
+    "        await grdm.login(page, idp_name_1, idp_username_1, idp_password_1, transition_timeout=transition_timeout)\n",
+    "\n",
+    "    await expect(launch_button).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1f849fbb",
    "metadata": {},
    "source": [
@@ -243,20 +284,35 @@
    "outputs": [],
    "source": [
     "async def _step(page):\n",
-    "    binder_entry = page.locator(f'//a[text() = \"{halted_binderhub_url}\"]')\n",
+    "    await page.locator('//a[text() = \"アドオン\"]').click()\n",
+    "    binder_entry = page.locator(f'//a[text() = \"{halted_hub[\"binderhub_url\"]}\"]')\n",
     "    if await binder_entry.count():\n",
     "        print('BinderHub entry already exists')\n",
     "        return\n",
     "    add_button = page.locator('//button[@href=\"#binderhubInputHost\"]')\n",
     "    await add_button.click()\n",
     "    await expect(page.locator('//input[@name = \"binderhub_url\"]')).to_be_visible(timeout=transition_timeout)\n",
-    "    await page.locator('//input[@name = \"binderhub_url\"]').fill(halted_binderhub_url)\n",
+    "    await page.locator('//input[@name = \"binderhub_url\"]').fill(halted_hub[\"binderhub_url\"])\n",
+    "    # Configure BinderHub OAuth\n",
+    "    await page.locator('//input[@name = \"binderhub_has_oauth_client\"]').check()\n",
+    "    await expect(page.locator('//input[@name = \"binderhub_has_oauth_client\"]')).to_be_checked(timeout=transition_timeout)\n",
+    "    await page.locator('//input[@name = \"binderhub_oauth_client_id\"]').fill(halted_hub[\"binderhub_oauth_client_id\"])\n",
+    "    await page.locator('//input[@name = \"binderhub_oauth_client_secret\"]').fill(halted_hub[\"binderhub_oauth_client_secret\"])\n",
+    "    # Configure JupyterHub OAuth\n",
+    "    await page.locator('//input[@name = \"jupyterhub_has_oauth_client\"]').check()\n",
+    "    await expect(page.locator('//input[@name = \"jupyterhub_has_oauth_client\"]')).to_be_checked(timeout=transition_timeout)\n",
+    "    await page.locator('//input[@name = \"jupyterhub_url\"]').fill(halted_hub[\"jupyterhub_url\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_oauth_client_id\"]').fill(halted_hub[\"jupyterhub_oauth_client_id\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_oauth_client_secret\"]').fill(halted_hub[\"jupyterhub_oauth_client_secret\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_admin_api_token\"]').fill(halted_hub[\"jupyterhub_admin_api_token\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_logout_url\"]').fill(halted_hub[\"jupyterhub_logout_url\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_max_servers\"]').fill(halted_hub[\"jupyterhub_max_servers\"])\n",
     "    # Tab to trigger any on-change events\n",
     "    await page.locator('//input[@name = \"binderhub_url\"]').press('Tab')\n",
     "    save_button = page.locator('//button[contains(@data-bind, \"hostCompleted\") and contains(text(), \"保存\")]')\n",
     "    await expect(save_button).to_be_enabled(timeout=transition_timeout)\n",
     "    await save_button.click()\n",
-    "    await expect(page.locator(f'//a[text() = \"{halted_binderhub_url}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator(f'//a[text() = \"{halted_hub[\"binderhub_url\"]}\"]')).to_be_visible(timeout=transition_timeout)\n",
     "\n",
     "await run_pw(_step)\n"
    ]
@@ -279,10 +335,10 @@
    "outputs": [],
    "source": [
     "async def _step(page):\n",
-    "    default_square = page.locator(f'//a[text() = \"{halted_binderhub_url}\"]/../..//i[contains(@class, \"fa-square\")]')\n",
+    "    default_square = page.locator(f'//a[text() = \"{halted_hub[\"binderhub_url\"]}\"]/../..//i[contains(@class, \"fa-square\")]')\n",
     "    if await default_square.count():\n",
     "        await default_square.click()\n",
-    "        await expect(page.locator(f'//a[text() = \"{halted_binderhub_url}\"]/../..//i[contains(@class, \"fa-check-square\")]')).to_be_visible(timeout=transition_timeout)\n",
+    "        await expect(page.locator(f'//a[text() = \"{halted_hub[\"binderhub_url\"]}\"]/../..//i[contains(@class, \"fa-check-square\")]')).to_be_visible(timeout=transition_timeout)\n",
     "    else:\n",
     "        print('BinderHub already selected')\n",
     "\n",


### PR DESCRIPTION
## Purpose

[RDM-ember-osf-webの解析機能に関するバグ修正PR](https://github.com/RCOSDP/RDM-ember-osf-web/pull/177)により、解析機能におけるBinderHub/JupyterHubのヘルスチェックはOAuthの認証用のURLが設定されている場合にのみ実行されるように修正された。本PRはこれに追従し、「OAuth連携する、現在稼働していないBinderHub」の例として用いるエントリに、認証用のURLが設定されるための修正を適用する。

## Changes

`テスト手順-BinderHub-BinderHubアドオン-停止中のBinderHubアドオン.ipynb` で、停止中のBinderHubとして指定したエントリにclient idやsecretを追加で指定して、認証用のURLが設定されるように修正した。

## Ticket

## Custom Test Configuration
<!-- Leave empty to use default settings. Specify custom settings to test with specific versions or fixes. -->
- RDM_REPOSITORY: 
- RDM_BRANCH: 
- RDM_MERGE:
<!-- RDM_MERGE: Set to false to test against the custom branch without merging -->
- OSF_IMAGE: 
- EMBER_IMAGE: chiku314/rdm-ember-osf-web:hotfix-gate-healthcheck
- CAS_IMAGE: 
- MFR_IMAGE: 
- WB_IMAGE:
- EXCLUDE_NOTEBOOKS: 
<!-- EXCLUDE_NOTEBOOKS: Comma-separated list of notebooks to exclude from tests -->