### PR TITLE
ローカルRDM向けBinderHubアドオンE2Eテスト群を追加

### DIFF
--- a/scripts/jupyterhub.py
+++ b/scripts/jupyterhub.py
@@ -1,0 +1,15 @@
+from playwright.async_api import expect
+
+async def login(page, username, password, transition_timeout=30000):
+    # Login to JupyterHub
+    jupyterhub_signin_button = page.locator('//*[@id = "login_submit"]')
+    await expect(jupyterhub_signin_button).to_be_visible(timeout=transition_timeout)
+    await page.locator('//*[@id = "username_input"]').fill(username)
+    await page.locator('//*[@id = "password_input"]').fill(password)
+    await jupyterhub_signin_button.click()
+
+async def authorize(page, transition_timeout=30000):
+    # JupyterHub authorizes a service (e.g. BinderHub addon of RDM OSF Integration)
+    authorize_button = page.locator('//*[@value = "Authorize"]')
+    await expect(authorize_button).to_be_visible(timeout=transition_timeout)
+    await authorize_button.click()

--- a/テスト手順-local-BinderHubアドオン-Dockerfile.ipynb
+++ b/テスト手順-local-BinderHubアドオン-Dockerfile.ipynb
@@ -1,0 +1,514 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6e2f9c9",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Dockerfile\n",
+    "from datetime import datetime\n",
+    "from getpass import getpass\n",
+    "import os\n",
+    "\n",
+    "rdm_url = None\n",
+    "idp_name_1 = None\n",
+    "idp_username_1 = None\n",
+    "idp_password_1 = None\n",
+    "\n",
+    "jupyterhub_username = None\n",
+    "jupyterhub_password = None\n",
+    "\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 60 * 1000\n",
+    "\n",
+    "project_name = None\n",
+    "\n",
+    "binderhub_post_build_script = '''#!/bin/bash\n",
+    "date > ~/uptime'''\n",
+    "binderhub_dockerfile_option = '!SINGLESPEED!'\n",
+    "binderhub_launch_timeout = 30 * 60 * 1000   # 30 minutes\n",
+    "dockerfile_custom_script = \"\"\"FROM gcr.io/nii-ap-ops/base/datascience-notebook:main-lab4.x\n",
+    "\n",
+    "COPY --chown=$NB_UID:$NB_GID . .\n",
+    "\"\"\"\n",
+    "binderhub_test_filename = 'grdm_test_file.txt'\n",
+    "binderhub_test_file_content = 'GRDM_FILE_SYNC_TEST'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "877ca5bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if idp_username_1 is None:\n",
+    "    idp_username_1 = input(prompt=f'Username for {idp_name_1}')\n",
+    "if idp_password_1 is None:\n",
+    "    idp_password_1 = getpass(prompt=f'Password for {idp_username_1}@{idp_name_1}')\n",
+    "if jupyterhub_username is None:\n",
+    "    jupyterhub_username = input(prompt='Username for JupyterHub')\n",
+    "if jupyterhub_password is None:\n",
+    "    jupyterhub_password = getpass(prompt=f'Password for {jupyterhub_username}@JupyterHub')\n",
+    "if project_name is None:\n",
+    "    project_name = datetime.now().strftime('TEST-BINDERHUB-%Y%m%d%H%M')\n",
+    "\n",
+    "project_url = None\n",
+    "project_created = False\n",
+    "environment_name = None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f687a78",
+   "metadata": {},
+   "source": [
+    "# BinderHubアドオン Dockerfile による解析環境の起動\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アドオン操作\n",
+    "- シナリオ名: Dockerfile基本イメージを使った解析環境の起動\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で1個作れる状態であること)\n",
+    "- 事前条件: なし"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22d81a74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "161eb58b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "import pandas as pd\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "from scripts import grdm, jupyterhub\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab039833",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "async def run_lab_command(page, command, expected_substring, run_wait_time=3000):\n",
+    "    editor = page.locator('div.jp-CodeCell div.cm-content').nth(0)\n",
+    "    await expect(editor).to_be_visible(timeout=transition_timeout)\n",
+    "    await editor.click()\n",
+    "    await editor.fill(command)\n",
+    "\n",
+    "    run_button = page.locator('//jp-button[@data-command = \"notebook:run-cell-and-select-next\"]')\n",
+    "    await expect(run_button).to_be_visible(timeout=transition_timeout)\n",
+    "    await run_button.click()\n",
+    "    await asyncio.sleep(run_wait_time / 1000)\n",
+    "\n",
+    "    output = page.locator(f'//*[contains(@class, \"jp-OutputArea\")]//*[text()[contains(., \"{expected_substring}\")]]')\n",
+    "    await expect(output).to_be_visible(timeout=transition_timeout)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92f1adcb",
+   "metadata": {},
+   "source": [
+    "## ウェブブラウザの新規プライベートウィンドウでLocal RDMトップページを表示する\n",
+    "\n",
+    "Local RDMトップページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0aa1cde5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(rdm_url, wait_until=\"networkidle\")\n",
+    "    consent_button = page.locator('//button[text() = \"同意する\"]')\n",
+    "    if await consent_button.count():\n",
+    "        await consent_button.click()\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eaa711a1",
+   "metadata": {},
+   "source": [
+    "## IdPを利用し、既存ユーザー1としてログインする\n",
+    "\n",
+    "Local RDMダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18c04159",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.login(page, idp_name_1, idp_username_1, idp_password_1, transition_timeout=transition_timeout)\n",
+    "    await grdm.expect_dashboard(page, transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "992d601d",
+   "metadata": {},
+   "source": [
+    "## Local RDMトップページを表示する\n",
+    "\n",
+    "ダッシュボードのプロジェクト一覧に先に作成したプロジェクトが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07d605d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_created\n",
+    "    project_created = await grdm.ensure_project_exists(page, project_name, transition_timeout=transition_timeout)\n",
+    "    if project_created:\n",
+    "        print(f'Created project: {project_name}')\n",
+    "    else:\n",
+    "        print(f'Project already exists: {project_name}')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef1ee68b",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードのプロジェクト一覧から作成したプロジェクトをクリックする\n",
+    "\n",
+    "作成したプロジェクトのプロジェクトダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0501c584",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_url\n",
+    "    await page.locator(f'//*[@data-test-dashboard-item-title and text() = \"{project_name}\"]').click()\n",
+    "    await expect(page.locator('//span[@id = \"nodeTitleEditable\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//a[text() = \"アドオン\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    project_url = page.url\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a067413d",
+   "metadata": {},
+   "source": [
+    "## BinderHubアドオンを有効化する\n",
+    "\n",
+    "アドオン利用規約の確認ダイアログが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8a4e8e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.enable_addon(page, 'GakuNin Federated Computing Services (Jupyter)', transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f170c173",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "582286b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    await jupyterhub.login(page, jupyterhub_username, jupyterhub_password, transition_timeout)\n",
+    "    await jupyterhub.authorize(page, transition_timeout)\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c8513bf",
+   "metadata": {},
+   "source": [
+    "## 基本イメージの「変更」をクリックする\n",
+    "\n",
+    "Dockerfileオプションが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "349260ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//*[@data-test-image-change]').click()\n",
+    "    await expect(page.locator(f'//*[@data-test-image-selection = \"{binderhub_dockerfile_option}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f01a5685",
+   "metadata": {},
+   "source": [
+    "## 「Dockerfileを用いたカスタムイメージ」をクリックする\n",
+    "\n",
+    "「Dockerfile」エディターが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fe89700",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator(f'//*[@data-test-image-selection = \"{binderhub_dockerfile_option}\"]').click()\n",
+    "    await expect(page.locator('//h3[text() = \"Dockerfile\"]/../..//textarea')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b8f1a03",
+   "metadata": {},
+   "source": [
+    "## 「Dockerfile」エディターにスクリプトを入力する\n",
+    "\n",
+    "入力内容が表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43d3b3ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    textarea = page.locator('//h3[text() = \"Dockerfile\"]/../..//textarea')\n",
+    "    await textarea.fill(dockerfile_custom_script)\n",
+    "    await textarea.press('Tab')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec0e719c",
+   "metadata": {},
+   "source": [
+    "## 「保存」をクリックする\n",
+    "\n",
+    "エラーメッセージが表示されないこと"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "221264c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//h3[text() = \"Dockerfile\"]/../..//button[text() = \"保存\"]').click()\n",
+    "    await asyncio.sleep(10)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4f81d6c",
+   "metadata": {},
+   "source": [
+    "## 「新しい解析環境を作成」をクリックする\n",
+    "\n",
+    "環境の起動を待つ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c4a1d5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    popup_future = page.wait_for_event('popup', timeout=binderhub_launch_timeout)\n",
+    "    await page.locator('//*[@data-test-binderhub-launch]').click()\n",
+    "    popup = await popup_future\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f537d0a",
+   "metadata": {},
+   "source": [
+    "## JupyterLabが表示されていることを確認する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d14b6ce0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@class = \"jp-LauncherCard\" and @title = \"Python 3 (ipykernel)\" and @data-category = \"Notebook\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6b3cffc",
+   "metadata": {},
+   "source": [
+    "## JupyterLabウィンドウを閉じる\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc5a287f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await close_latest_page()\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2365ed0",
+   "metadata": {},
+   "source": [
+    "終了処理を実施する。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96672e1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75591d55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/テスト手順-local-BinderHubアドオン-repo2docker.ipynb
+++ b/テスト手順-local-BinderHubアドオン-repo2docker.ipynb
@@ -1,0 +1,954 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c641abf8",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from getpass import getpass\n",
+    "\n",
+    "rdm_url = None\n",
+    "idp_name_1 = None\n",
+    "idp_username_1 = None\n",
+    "idp_password_1 = None\n",
+    "\n",
+    "jupyterhub_username = None\n",
+    "jupyterhub_password = None\n",
+    "\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "project_name = None\n",
+    "transition_timeout = 60 * 1000\n",
+    "\n",
+    "binderhub_base_image = '#repo2docker#python=3.12.*,r-base=4.4.*'\n",
+    "\n",
+    "binderhub_apt_package = 'sl'\n",
+    "binderhub_conda_package = 'awscli'\n",
+    "binderhub_pip_package = 'papermill'\n",
+    "binderhub_r_package = 'eegkit'\n",
+    "\n",
+    "binderhub_post_build_script = '''#!/bin/bash\n",
+    "date > ~/uptime'''\n",
+    "binderhub_binder_files = ['apt.txt', 'environment.yml', 'install.R', 'postBuild']\n",
+    "binderhub_launch_timeout = 30 * 60 * 1000   # 30 minutes\n",
+    "binderhub_test_filename = 'grdm_test_file.txt'\n",
+    "binderhub_test_file_content = 'GRDM_FILE_SYNC_TEST'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85c7c2fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if rdm_url is None:\n",
+    "    rdm_url = input(prompt=f'RDM URL: ')\n",
+    "if idp_name_1 is None:\n",
+    "    idp_name_1 = input(prompt=f'IdP Name: ')\n",
+    "if idp_username_1 is None:\n",
+    "    idp_username_1 = input(prompt=f'Username for {idp_name_1}')\n",
+    "if idp_password_1 is None:\n",
+    "    idp_password_1 = getpass(prompt=f'Password for {idp_username_1}@{idp_name_1}')\n",
+    "if jupyterhub_username is None:\n",
+    "    jupyterhub_username = input(prompt='Username for JupyterHub')\n",
+    "if jupyterhub_password is None:\n",
+    "    jupyterhub_password = getpass(prompt=f'Password for {jupyterhub_username}@JupyterHub')\n",
+    "if project_name is None:\n",
+    "    project_name = datetime.now().strftime('TEST-BINDERHUB-%Y%m%d%H%M')\n",
+    "\n",
+    "project_url = None\n",
+    "project_created = False\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "603cb958",
+   "metadata": {},
+   "source": [
+    "# BinderHubアドオン repo2docker による解析環境の起動\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アドオン操作\n",
+    "- シナリオ名: repo2docker基本イメージを使った解析環境の起動\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で1個作れる状態であること)\n",
+    "- 事前条件: なし\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2fde640",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "579a2f7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "import pandas as pd\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "from scripts import grdm, jupyterhub\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b8a2b9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "async def run_lab_command(page, command, expected_substring, run_wait_time=3000):\n",
+    "    editor = page.locator('div.jp-CodeCell div.cm-content').first\n",
+    "    await expect(editor).to_be_visible(timeout=transition_timeout)\n",
+    "    await editor.click()\n",
+    "    await editor.fill(command)\n",
+    "\n",
+    "    run_button = page.locator('//jp-button[@data-command = \"notebook:run-cell-and-select-next\"]')\n",
+    "    await expect(run_button).to_be_visible(timeout=transition_timeout)\n",
+    "    await run_button.click()\n",
+    "    await asyncio.sleep(run_wait_time / 1000)\n",
+    "\n",
+    "    output = page.locator(f'//*[contains(@class, \"jp-OutputArea\")]//*[text()[contains(., \"{expected_substring}\")]]')\n",
+    "    await expect(output).to_be_visible(timeout=transition_timeout)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eef0ced0",
+   "metadata": {},
+   "source": [
+    "## ウェブブラウザの新規プライベートウィンドウでLocal RDMトップページを表示する\n",
+    "\n",
+    "Local RDMトップページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51349abc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(rdm_url, wait_until=\"networkidle\")\n",
+    "    consent_button = page.locator('//button[text() = \"同意する\"]')\n",
+    "    if await consent_button.count():\n",
+    "        await consent_button.click()\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "822c10dd",
+   "metadata": {},
+   "source": [
+    "## IdPを利用し、既存ユーザー1としてログインする\n",
+    "\n",
+    "Local RDMダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eda14d1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.login(page, idp_name_1, idp_username_1, idp_password_1, transition_timeout=transition_timeout)\n",
+    "    await grdm.expect_dashboard(page, transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca377901",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードから「新規プロジェクト作成」をクリックする\n",
+    "\n",
+    "指定したプロジェクトが存在しない場合、新規プロジェクトが作成されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16fa88c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_created\n",
+    "    project_created = await grdm.ensure_project_exists(page, project_name, transition_timeout=transition_timeout)\n",
+    "    if project_created:\n",
+    "        print(f'Created project: {project_name}')\n",
+    "    else:\n",
+    "        print(f'Project already exists: {project_name}')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca9bd1f0",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードのプロジェクト一覧から作成したプロジェクトをクリックする\n",
+    "\n",
+    "プロジェクトダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "528782f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_url\n",
+    "    await page.locator(f'//*[@data-test-dashboard-item-title and text() = \"{project_name}\"]').click()\n",
+    "    await expect(page.locator('//span[@id = \"nodeTitleEditable\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//a[text() = \"アドオン\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    project_url = page.url\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2dc3bf71",
+   "metadata": {},
+   "source": [
+    "## BinderHubアドオンを有効化する\n",
+    "\n",
+    "アドオン利用規約の確認ダイアログが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d84eddea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.enable_addon(page, 'GakuNin Federated Computing Services (Jupyter)', transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cede768",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55dfc15d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    await jupyterhub.login(page, jupyterhub_username, jupyterhub_password, transition_timeout)\n",
+    "    await jupyterhub.authorize(page, transition_timeout)\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c784d9c8",
+   "metadata": {},
+   "source": [
+    "## 基本イメージの「変更」をクリックする\n",
+    "\n",
+    "基本イメージ一覧が表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14fdad40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    addon_name = 'GakuNin Federated Computing Services (Jupyter)'\n",
+    "    enable_locator = page.locator(f'//div[@full_name = \"{addon_name}\"]//a[text() = \"有効にする\"]')\n",
+    "    if await enable_locator.count():\n",
+    "        await enable_locator.click()\n",
+    "        confirm_button = page.locator('//button[@data-bb-handler = \"confirm\"]')\n",
+    "        await expect(confirm_button).to_be_visible(timeout=transition_timeout)\n",
+    "        await confirm_button.click()\n",
+    "    else:\n",
+    "        print('Addon already enabled')\n",
+    "\n",
+    "await run_pw(_step)\n",
+    "async def _step(page):\n",
+    "    await page.locator('//*[@data-test-image-change]').click()\n",
+    "    await expect(page.locator(f'//*[@data-test-image-selection = \"{binderhub_base_image}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1972dc69",
+   "metadata": {},
+   "source": [
+    "## 「Python 3.12 + R 4.4 (JupyterLab 4.x)」をクリックする\n",
+    "\n",
+    "「追加パッケージ」エディターが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "389ce903",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator(f'//*[@data-test-image-selection = \"{binderhub_base_image}\"]').click()\n",
+    "    await expect(page.locator('//*[@data-test-package-add]')).not_to_have_count(0, timeout=transition_timeout)\n",
+    "    await expect(page.locator('//div[@data-test-package-editor = \"apt\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//div[@data-test-package-editor = \"conda\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//div[@data-test-package-editor = \"pip\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//div[@data-test-package-editor = \"rmran\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec2f482c",
+   "metadata": {},
+   "source": [
+    "## 「apt-get」の「+追加」をクリックし、パッケージを登録する\n",
+    "\n",
+    "パッケージ名がaptに表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac0a344b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//div[@data-test-package-editor = \"apt\"]//*[@data-test-package-add]').click()\n",
+    "    field = page.locator('//input[@name = \"package_name\"]')\n",
+    "    await expect(field).to_be_visible(timeout=transition_timeout)\n",
+    "    await field.fill(binderhub_apt_package)\n",
+    "    await page.locator('//button[@data-test-package-item-confirm]').click()\n",
+    "    await expect(page.locator(f'//div[@data-test-package-editor = \"apt\"]//*[text() = \"{binderhub_apt_package}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await asyncio.sleep(transition_timeout / 1000)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0e54acc",
+   "metadata": {},
+   "source": [
+    "## 「conda」の「+追加」をクリックし、パッケージを登録する\n",
+    "\n",
+    "パッケージ名がcondaに表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78469f32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//div[@data-test-package-editor = \"conda\"]//*[@data-test-package-add]').click()\n",
+    "    field = page.locator('//input[@name = \"package_name\"]')\n",
+    "    await expect(field).to_be_visible(timeout=transition_timeout)\n",
+    "    await field.fill(binderhub_conda_package)\n",
+    "    await page.locator('//button[@data-test-package-item-confirm]').click()\n",
+    "    await expect(page.locator(f'//div[@data-test-package-editor = \"conda\"]//*[text() = \"{binderhub_conda_package}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await asyncio.sleep(transition_timeout / 1000)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03e5f3fd",
+   "metadata": {},
+   "source": [
+    "## 「pip」の「+追加」をクリックし、パッケージを登録する\n",
+    "\n",
+    "パッケージ名がpipに表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2c9ba8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//div[@data-test-package-editor = \"pip\"]//*[@data-test-package-add]').click()\n",
+    "    field = page.locator('//input[@name = \"package_name\"]')\n",
+    "    await expect(field).to_be_visible(timeout=transition_timeout)\n",
+    "    await field.fill(binderhub_pip_package)\n",
+    "    await page.locator('//button[@data-test-package-item-confirm]').click()\n",
+    "    await expect(page.locator(f'//div[@data-test-package-editor = \"pip\"]//*[text() = \"{binderhub_pip_package}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await asyncio.sleep(transition_timeout / 1000)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40988528",
+   "metadata": {},
+   "source": [
+    "## 「R (CRAN)」の「+追加」をクリックし、パッケージを登録する\n",
+    "\n",
+    "パッケージ名がR (CRAN)に表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84d1c03a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//div[@data-test-package-editor = \"rmran\"]//*[@data-test-package-add]').click()\n",
+    "    field = page.locator('//input[@name = \"package_name\"]')\n",
+    "    await expect(field).to_be_visible(timeout=transition_timeout)\n",
+    "    await field.fill(binderhub_r_package)\n",
+    "    await page.locator('//button[@data-test-package-item-confirm]').click()\n",
+    "    await expect(page.locator(f'//div[@data-test-package-editor = \"rmran\"]//*[text() = \"{binderhub_r_package}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await asyncio.sleep(transition_timeout / 1000)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b009a6f7",
+   "metadata": {},
+   "source": [
+    "## 「自動実行スクリプト」をクリックする\n",
+    "\n",
+    "スクリプトエディタが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ca269a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//h3//button/*[contains(@class, \"fa-chevron-right\")]').click()\n",
+    "    await expect(page.locator('//textarea[@data-test-post-build]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//button[@data-test-save-post-build]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "793682fa",
+   "metadata": {},
+   "source": [
+    "## スクリプトを入力し、保存する\n",
+    "\n",
+    "保存ボタンが有効になり、保存後に無効化されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a92e4e33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    textarea = page.locator('//textarea[@data-test-post-build]')\n",
+    "    await textarea.fill(binderhub_post_build_script)\n",
+    "    await textarea.press('Tab')\n",
+    "    save_button = page.locator('//button[@data-test-save-post-build]')\n",
+    "    await expect(save_button).to_be_enabled(timeout=transition_timeout)\n",
+    "    await save_button.click()\n",
+    "    await expect(save_button).to_be_disabled(timeout=transition_timeout)\n",
+    "    await page.wait_for_load_state('networkidle')\n",
+    "    await asyncio.sleep(transition_timeout / 1000)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b862eb7e",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「ファイル」をクリックする\n",
+    "\n",
+    "フォルダ「.binder」が作成されていること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c41088e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//*[@data-test-node-navbar-link = \"files\"]').click()\n",
+    "    binder_folder = page.locator('//*[text() = \".binder\"]/../..//*[contains(@class, \"fa-plus\")]')\n",
+    "    await expect(binder_folder).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3ed443a",
+   "metadata": {},
+   "source": [
+    "## 「.binder」フォルダを開き、生成されたファイルを確認する\n",
+    "\n",
+    "apt.txt などのファイルが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "222f4349",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    toggle = page.locator('//*[text() = \".binder\"]/../..//*[contains(@class, \"fa-plus\")]')\n",
+    "    await toggle.click()\n",
+    "    for filename in binderhub_binder_files:\n",
+    "        await expect(page.locator(f'//*[text() = \"{filename}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "619e9296",
+   "metadata": {},
+   "source": [
+    "## プロジェクトのストレージにテストファイルをアップロードする\n",
+    "\n",
+    "ファイルがアップロードされ、ファイル一覧に表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cd9ae22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    # テストファイルを作成\n",
+    "    test_filepath = os.path.join(work_dir, binderhub_test_filename)\n",
+    "    with open(test_filepath, 'w') as f:\n",
+    "        f.write(binderhub_test_file_content)\n",
+    "\n",
+    "    # NII Storageを選択してアップロード\n",
+    "    await grdm.get_select_storage_title_locator(page, 'NII Storage').click()\n",
+    "    await grdm.upload_file(page, test_filepath)\n",
+    "    await expect(grdm.get_select_file_title_locator(page, binderhub_test_filename)).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "880319f4",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "614784e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce2f2f8d",
+   "metadata": {},
+   "source": [
+    "## 「新しい解析環境を作成」をクリックする\n",
+    "\n",
+    "環境の起動を待つ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36b45ff1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    popup_future = page.wait_for_event('popup', timeout=binderhub_launch_timeout)\n",
+    "    await page.locator('//*[@data-test-binderhub-launch]').click()\n",
+    "    popup = await popup_future\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93eb2363",
+   "metadata": {},
+   "source": [
+    "## JupyterLabが表示されていることを確認する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c700cfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@class = \"jp-LauncherCard\" and @title = \"Python 3 (ipykernel)\" and @data-category = \"Notebook\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90979df8",
+   "metadata": {},
+   "source": [
+    "## 新規Notebookを作成する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffa2eff0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    launcher_label = 'Python 3 (ipykernel)'\n",
+    "    launcher = page.locator(f'//*[@class = \"jp-LauncherCard\" and @title = \"{launcher_label}\" and @data-category = \"Notebook\"]')\n",
+    "    await expect(launcher).to_be_visible(timeout=transition_timeout)\n",
+    "    await launcher.click()\n",
+    "\n",
+    "    await expect(page.locator('//*[contains(@class, \"jp-Notebook-ExecutionIndicator\") and @data-status=\"idle\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d57517e",
+   "metadata": {},
+   "source": [
+    "## 「!which /usr/games/sl」を実行して結果を確認する\n",
+    "\n",
+    "コマンドの出力に `/usr/games/sl` が含まれること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f162eb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await run_lab_command(page, '!which /usr/games/sl', '/usr/games/sl')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7751944",
+   "metadata": {},
+   "source": [
+    "## 「!aws」を実行して結果を確認する\n",
+    "\n",
+    "コマンドの出力に `usage: aws` が含まれること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fc2d246",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await run_lab_command(page, '!aws', 'usage: aws')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feb13e4a",
+   "metadata": {},
+   "source": [
+    "## 「!papermill」を実行して結果を確認する\n",
+    "\n",
+    "コマンドの出力に `Usage: papermill` が含まれること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5aa04743",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await run_lab_command(page, '!papermill', 'Usage: papermill')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3721a0f0",
+   "metadata": {},
+   "source": [
+    "## プロジェクトのファイルがコピーされていることを確認する\n",
+    "\n",
+    "テストファイルの内容が出力されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a85a95b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await run_lab_command(page, f'!cat {binderhub_test_filename}', binderhub_test_file_content)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d301798",
+   "metadata": {},
+   "source": [
+    "## Notebookを閉じる"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5685ae5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    close_icon = page.locator('//*[contains(@class, \"lm-mod-current\")]//*[contains(@class, \"lm-TabBar-tabCloseIcon\")]')\n",
+    "    await expect(close_icon).to_be_visible(timeout=transition_timeout)\n",
+    "    await close_icon.click()\n",
+    "\n",
+    "    discard_button = page.locator('//div[text() = \"Discard\"]')\n",
+    "    await expect(discard_button).to_be_visible(timeout=transition_timeout)\n",
+    "    await discard_button.click()\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "929374fb",
+   "metadata": {},
+   "source": [
+    "## 「R」ランチャーを起動する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cda8f58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    launcher_label = 'R'\n",
+    "    launcher = page.locator(f'//*[@class = \"jp-LauncherCard\" and @title = \"{launcher_label}\" and @data-category = \"Notebook\"]')\n",
+    "    await expect(launcher).to_be_visible(timeout=transition_timeout)\n",
+    "    await launcher.click()\n",
+    "    await expect(page.locator('div.jp-CodeCell div.cm-content').first).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7acb415f",
+   "metadata": {},
+   "source": [
+    "## 「R」ランチャーで `library(eegkit)` を実行する\n",
+    "\n",
+    "出力に `Loading required package: eegkitdata` が含まれること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "715e2271",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[contains(@class, \"jp-Notebook-ExecutionIndicator\") and @data-status=\"idle\"]')).to_be_visible(timeout=10 * 1000)\n",
+    "    await run_lab_command(page, 'library(eegkit)', 'Loading required package: eegkitdata')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e98a033",
+   "metadata": {},
+   "source": [
+    "## JupyterLabウィンドウを閉じる"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ed7ea63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await close_latest_page()\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0827d295",
+   "metadata": {},
+   "source": [
+    "終了処理を実施する。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13d755ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0901bf05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/テスト手順-local-BinderHubアドオン-アドオン追加.ipynb
+++ b/テスト手順-local-BinderHubアドオン-アドオン追加.ipynb
@@ -1,0 +1,449 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f226930",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from getpass import getpass\n",
+    "\n",
+    "rdm_url = None\n",
+    "idp_name_1 = None\n",
+    "idp_username_1 = None\n",
+    "idp_password_1 = None\n",
+    "\n",
+    "jupyterhub_username = None\n",
+    "jupyterhub_password = None\n",
+    "\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 60 * 1000\n",
+    "\n",
+    "binderhub_binderhub_url = None\n",
+    "binderhub_launch_timeout = 30 * 60 * 1000   # 30 minutes\n",
+    "\n",
+    "project_name = None\n",
+    "\n",
+    "# Use Firefox for popup handling (Chromium has issues with popup events)\n",
+    "browser_type = 'firefox'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aff8b10c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if rdm_url is None:\n",
+    "    rdm_url = input(prompt=f'RDM URL: ')\n",
+    "if idp_name_1 is None:\n",
+    "    idp_name_1 = input(prompt=f'IdP Name: ')\n",
+    "if idp_username_1 is None:\n",
+    "    idp_username_1 = input(prompt=f'Username for {idp_name_1}')\n",
+    "if idp_password_1 is None:\n",
+    "    idp_password_1 = getpass(prompt=f'Password for {idp_username_1}@{idp_name_1}')\n",
+    "if jupyterhub_username is None:\n",
+    "    jupyterhub_username = input(prompt='Username for JupyterHub')\n",
+    "if jupyterhub_password is None:\n",
+    "    jupyterhub_password = getpass(prompt=f'Password for {jupyterhub_username}@JupyterHub')\n",
+    "if project_name is None:\n",
+    "    project_name = datetime.now().strftime('TEST-BINDERHUB-%Y%m%d%H%M')\n",
+    "\n",
+    "project_url = None\n",
+    "project_created = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "886a2dac",
+   "metadata": {},
+   "source": [
+    "# プロジェクトに対するBinderHubアドオンの登録\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アカウント設定\n",
+    "- シナリオ名: プロジェクトへの有効化\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で1個作れる状態であること)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "772b2cca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35b4436c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "import pandas as pd\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "from scripts import grdm, jupyterhub\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0da0d1cc",
+   "metadata": {},
+   "source": [
+    "## ウェブブラウザの新規プライベートウィンドウでLocal RDMトップページを表示する\n",
+    "\n",
+    "Local RDMトップページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "290bbecd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(rdm_url, wait_until='networkidle')\n",
+    "    consent_button = page.locator('//button[text() = \"同意する\"]')\n",
+    "    if await consent_button.count():\n",
+    "        await consent_button.click()\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cab95b0",
+   "metadata": {},
+   "source": [
+    "## IdPを利用し、既存ユーザー1としてログインする\n",
+    "\n",
+    "Local RDMダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1afb958d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.login(page, idp_name_1, idp_username_1, idp_password_1, transition_timeout=transition_timeout)\n",
+    "    await grdm.expect_dashboard(page, transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6685c470",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードから「新規プロジェクト作成」をクリックする\n",
+    "\n",
+    "指定したプロジェクトが存在しない場合、新規プロジェクトが作成されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f36c5855",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_created\n",
+    "    project_created = await grdm.ensure_project_exists(page, project_name, transition_timeout=transition_timeout)\n",
+    "    if project_created:\n",
+    "        print(f'Created project: {project_name}')\n",
+    "    else:\n",
+    "        print(f'Project already exists: {project_name}')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0626a5ef",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードのプロジェクト一覧から作成したプロジェクトをクリックする\n",
+    "\n",
+    "プロジェクトダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50c00268",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_url\n",
+    "    await page.locator(f'//*[@data-test-dashboard-item-title and text() = \"{project_name}\"]').click()\n",
+    "    await expect(page.locator('//span[@id = \"nodeTitleEditable\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//a[text() = \"アドオン\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    project_url = page.url\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0c06d3c",
+   "metadata": {},
+   "source": [
+    "## BinderHubアドオンを有効化する\n",
+    "\n",
+    "アドオン利用規約の確認ダイアログが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28f190a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.enable_addon(page, 'GakuNin Federated Computing Services (Jupyter)', transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f849fbb",
+   "metadata": {},
+   "source": [
+    "## 「BinderHubを追加」ボタンをクリックする\n",
+    "\n",
+    "BinderHubクライアント情報の設定ダイアログが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "355294b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    binder_entry = page.locator(f'//a[text() = \"{binderhub_binderhub_url}\"]')\n",
+    "    if await binder_entry.count():\n",
+    "        print('BinderHub entry already exists')\n",
+    "        return\n",
+    "    add_button = page.locator('//button[@href=\"#binderhubInputHost\"]')\n",
+    "    await add_button.click()\n",
+    "    await expect(page.locator('//input[@name = \"binderhub_url\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await page.locator('//input[@name = \"binderhub_url\"]').fill(binderhub_binderhub_url)\n",
+    "    # Tab to trigger any on-change events\n",
+    "    await page.locator('//input[@name = \"binderhub_url\"]').press('Tab')\n",
+    "    save_button = page.locator('//button[contains(@data-bind, \"hostCompleted\") and contains(text(), \"保存\")]')\n",
+    "    await expect(save_button).to_be_enabled(timeout=transition_timeout)\n",
+    "    await save_button.click()\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f10608f",
+   "metadata": {},
+   "source": [
+    "## 追加したBinderHubのチェックボックスをクリックする\n",
+    "\n",
+    "Default BinderHub URL が追加したBinderHubのURLになること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "847b10ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    default_square = page.locator(f'//a[text() = \"{binderhub_binderhub_url}\"]/../..//i[contains(@class, \"fa-square\")]')\n",
+    "    if await default_square.count():\n",
+    "        await default_square.click()\n",
+    "        await expect(page.locator(f'//a[text() = \"{binderhub_binderhub_url}\"]/../..//i[contains(@class, \"fa-check-square\")]')).to_be_visible(timeout=transition_timeout)\n",
+    "    else:\n",
+    "        print('BinderHub already selected')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb7e10e0",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "795f34f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    await jupyterhub.login(page, jupyterhub_username, jupyterhub_password, transition_timeout)\n",
+    "    await jupyterhub.authorize(page, transition_timeout)\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0fca2f9",
+   "metadata": {},
+   "source": [
+    "## 「新しい解析環境を作成」をクリックする\n",
+    "\n",
+    "環境の起動を待つ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8580a11a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    popup_future = page.wait_for_event('popup', timeout=binderhub_launch_timeout)\n",
+    "    await page.locator('//*[@data-test-binderhub-launch]').click()\n",
+    "    popup = await popup_future\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad02e6e9",
+   "metadata": {},
+   "source": [
+    "## JupyterLabが表示されていることを確認する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54a033fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@class = \"jp-LauncherCard\" and @title = \"Python 3 (ipykernel)\" and @data-category = \"Notebook\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12e74099",
+   "metadata": {},
+   "source": [
+    "## JupyterLabウィンドウを閉じる"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f16811e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await close_latest_page()\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0d9d37f",
+   "metadata": {},
+   "source": [
+    "終了処理を実施する。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9da116b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a68c393",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/テスト手順-local-BinderHubアドオン-デフォルトストレージのコピー制御.ipynb
+++ b/テスト手順-local-BinderHubアドオン-デフォルトストレージのコピー制御.ipynb
@@ -1,0 +1,947 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdc90dbe",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Copy Default Storage\n",
+    "\n",
+    "from datetime import datetime\n",
+    "from getpass import getpass\n",
+    "import os\n",
+    "\n",
+    "rdm_url = None\n",
+    "idp_name_1 = None\n",
+    "idp_username_1 = None\n",
+    "idp_password_1 = None\n",
+    "\n",
+    "jupyterhub_username = None\n",
+    "jupyterhub_password = None\n",
+    "\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 60 * 1000\n",
+    "\n",
+    "project_name = None\n",
+    "\n",
+    "binderhub_post_build_script = '''#!/bin/bash\n",
+    "date > ~/uptime'''\n",
+    "binderhub_dockerfile_option = '!SINGLESPEED!'\n",
+    "binderhub_launch_timeout = 30 * 60 * 1000 # 30 minutes\n",
+    "dockerfile_custom_script = \"\"\"FROM gcr.io/nii-ap-ops/base/datascience-notebook:main-lab4.x\n",
+    "\n",
+    "COPY --chown=$NB_UID:$NB_GID . .\n",
+    "\"\"\"\n",
+    "binderhub_test_filename = 'grdm_test_file.txt'\n",
+    "binderhub_test_file_content = 'GRDM_FILE_SYNC_TEST'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb9912cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if idp_username_1 is None:\n",
+    "    idp_username_1 = input(prompt=f'Username for {idp_name_1}')\n",
+    "if idp_password_1 is None:\n",
+    "    idp_password_1 = getpass(prompt=f'Password for {idp_username_1}@{idp_name_1}')\n",
+    "if jupyterhub_username is None:\n",
+    "    jupyterhub_username = input(prompt='Username for JupyterHub')\n",
+    "if jupyterhub_password is None:\n",
+    "    jupyterhub_password = getpass(prompt=f'Password for {jupyterhub_username}@JupyterHub')\n",
+    "if project_name is None:\n",
+    "    project_name = datetime.now().strftime('TEST-BINDERHUB-%Y%m%d%H%M')\n",
+    "\n",
+    "project_url = None\n",
+    "project_created = False\n",
+    "environment_name = None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19ec85ef",
+   "metadata": {},
+   "source": [
+    "# BinderHubアドオン デフォルトストレージのコピー制御\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アドオン操作\n",
+    "- シナリオ名: デフォルトストレージのコピー制御\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で3個作れる状態であること)\n",
+    "- 事前条件: なし"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27944eae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "823dfd70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "import pandas as pd\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "from scripts import grdm, jupyterhub\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74f7130b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "async def run_lab_command(page, command, expected_substring, run_wait_time=3000):\n",
+    "    editor = page.locator('div.jp-CodeCell div.cm-content').nth(0)\n",
+    "    await expect(editor).to_be_visible(timeout=transition_timeout)\n",
+    "    await editor.click()\n",
+    "    await editor.fill(command)\n",
+    "\n",
+    "    run_button = page.locator('//jp-button[@data-command = \"notebook:run-cell-and-select-next\"]')\n",
+    "    await expect(run_button).to_be_visible(timeout=transition_timeout)\n",
+    "    await run_button.click()\n",
+    "    await asyncio.sleep(run_wait_time / 1000)\n",
+    "\n",
+    "    output = page.locator(f'//*[contains(@class, \"jp-OutputArea\")]//*[text()[contains(., \"{expected_substring}\")]]')\n",
+    "    await expect(output).to_be_visible(timeout=transition_timeout)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7865a5f1",
+   "metadata": {},
+   "source": [
+    "## ウェブブラウザの新規プライベートウィンドウでGRDMトップページを表示する\n",
+    "\n",
+    "Local RDMトップページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "396d27c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(rdm_url, wait_until=\"networkidle\")\n",
+    "    consent_button = page.locator('//button[text() = \"同意する\"]')\n",
+    "    if await consent_button.count():\n",
+    "        await consent_button.click()\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c0e312b",
+   "metadata": {},
+   "source": [
+    "## IdPを利用し、既存ユーザー1としてログインする\n",
+    "\n",
+    "Local RDMダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b8a7c1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.login(page, idp_name_1, idp_username_1, idp_password_1, transition_timeout=transition_timeout)\n",
+    "    await grdm.expect_dashboard(page, transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81caff4e",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードから「新規プロジェクト作成」をクリックする\n",
+    "\n",
+    "指定したプロジェクトが存在しない場合、新規プロジェクトが作成されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e5a632d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_created\n",
+    "    project_created = await grdm.ensure_project_exists(page, project_name, transition_timeout=transition_timeout)\n",
+    "    if project_created:\n",
+    "        print(f'Created project: {project_name}')\n",
+    "    else:\n",
+    "        print(f'Project already exists: {project_name}')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ba840eb",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードのプロジェクト一覧から作成したプロジェクトをクリックする\n",
+    "\n",
+    "プロジェクトダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee51438f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_url\n",
+    "    await page.locator(f'//*[@data-test-dashboard-item-title and text() = \"{project_name}\"]').click()\n",
+    "    await expect(page.locator('//span[@id = \"nodeTitleEditable\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//a[text() = \"アドオン\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    project_url = page.url\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "876012c3",
+   "metadata": {},
+   "source": [
+    "## BinderHubアドオンを有効化する\n",
+    "\n",
+    "アドオン利用規約の確認ダイアログが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "531b4128",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.enable_addon(page, 'GakuNin Federated Computing Services (Jupyter)', transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57fa595f",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "126b7af8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    await jupyterhub.login(page, jupyterhub_username, jupyterhub_password, transition_timeout)\n",
+    "    await jupyterhub.authorize(page, transition_timeout)\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e10b0a31",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「ファイル」をクリックする\n",
+    "\n",
+    "フォルダ「.binder」が作成されていること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8910e844",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//*[@data-test-node-navbar-link = \"files\"]').click()\n",
+    "    binder_folder = page.locator('//*[text() = \".binder\"]/../..//*[contains(@class, \"fa-plus\")]')\n",
+    "    await expect(binder_folder).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05f2ef26",
+   "metadata": {},
+   "source": [
+    "## プロジェクトのストレージにテストファイルをアップロードする\n",
+    "\n",
+    "ファイルがアップロードされ、ファイル一覧に表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7f42114",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    # テストファイルを作成\n",
+    "    test_filepath = os.path.join(work_dir, binderhub_test_filename)\n",
+    "    with open(test_filepath, 'w') as f:\n",
+    "        f.write(binderhub_test_file_content)\n",
+    "\n",
+    "    # NII Storageを選択してアップロード\n",
+    "    await grdm.get_select_storage_title_locator(page, 'NII Storage').click()\n",
+    "    await grdm.upload_file(page, test_filepath)\n",
+    "    await expect(grdm.get_select_file_title_locator(page, binderhub_test_filename)).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7337a8f6",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "122f315b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c458fa",
+   "metadata": {},
+   "source": [
+    "## 「新しい解析環境を作成」をクリックする\n",
+    "\n",
+    "環境の起動を待つ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4c84f83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    popup_future = page.wait_for_event('popup', timeout=binderhub_launch_timeout)\n",
+    "    await page.locator('//*[@data-test-binderhub-launch]').click()\n",
+    "    popup = await popup_future\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "100cf014",
+   "metadata": {},
+   "source": [
+    "## JupyterLabが表示されていることを確認する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b90b3bf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@class = \"jp-LauncherCard\" and @title = \"Python 3 (ipykernel)\" and @data-category = \"Notebook\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6250ddf1",
+   "metadata": {},
+   "source": [
+    "## 新規Notebookを作成する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91cf9bf1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    launcher_label = 'Python 3 (ipykernel)'\n",
+    "    launcher = page.locator(f'//*[@class = \"jp-LauncherCard\" and @title = \"{launcher_label}\" and @data-category = \"Notebook\"]')\n",
+    "    await expect(launcher).to_be_visible(timeout=transition_timeout)\n",
+    "    await launcher.click()\n",
+    "\n",
+    "    await expect(page.locator('//*[contains(@class, \"jp-Notebook-ExecutionIndicator\") and @data-status=\"idle\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f2f8de0",
+   "metadata": {},
+   "source": [
+    "## プロジェクトのファイルがコピーされていることを確認する\n",
+    "\n",
+    "テストファイルの内容が出力されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53d74ec7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await run_lab_command(page, f'!cat {binderhub_test_filename}', binderhub_test_file_content)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7c03649",
+   "metadata": {},
+   "source": [
+    "## Notebookを閉じる"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b8935ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    close_icon = page.locator('//*[contains(@class, \"lm-mod-current\")]//*[contains(@class, \"lm-TabBar-tabCloseIcon\")]')\n",
+    "    await expect(close_icon).to_be_visible(timeout=transition_timeout)\n",
+    "    await close_icon.click()\n",
+    "\n",
+    "    discard_button = page.locator('//div[text() = \"Discard\"]')\n",
+    "    await expect(discard_button).to_be_visible(timeout=transition_timeout)\n",
+    "    await discard_button.click()\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2390356b",
+   "metadata": {},
+   "source": [
+    "## JupyterLabウィンドウを閉じる"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b7a4dce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await close_latest_page()\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67c9d76d",
+   "metadata": {},
+   "source": [
+    "## 「デフォルトストレージの内容をコピーする」チェックボックスをオフにする\n",
+    "\n",
+    "チェックボックスがオフになること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "710ab128",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    checkbox = page.locator('//*[@data-test-copy-default-storage]')\n",
+    "    await expect(checkbox).to_be_checked(timeout=transition_timeout)\n",
+    "    await checkbox.click()\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b3537ee",
+   "metadata": {},
+   "source": [
+    "## 「新しい解析環境を作成」をクリックする\n",
+    "\n",
+    "環境の起動を待つ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae6bae81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    popup_future = page.wait_for_event('popup', timeout=binderhub_launch_timeout)\n",
+    "    await page.locator('//*[@data-test-binderhub-launch]').click()\n",
+    "    popup = await popup_future\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfaa08a7",
+   "metadata": {},
+   "source": [
+    "## JupyterLabが表示されていることを確認する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a41751d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@class = \"jp-LauncherCard\" and @title = \"Python 3 (ipykernel)\" and @data-category = \"Notebook\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8e2f9a0",
+   "metadata": {},
+   "source": [
+    "## 新規Notebookを作成する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8924c471",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    launcher_label = 'Python 3 (ipykernel)'\n",
+    "    launcher = page.locator(f'//*[@class = \"jp-LauncherCard\" and @title = \"{launcher_label}\" and @data-category = \"Notebook\"]')\n",
+    "    await expect(launcher).to_be_visible(timeout=transition_timeout)\n",
+    "    await launcher.click()\n",
+    "\n",
+    "    await expect(page.locator('//*[contains(@class, \"jp-Notebook-ExecutionIndicator\") and @data-status=\"idle\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d0f49d0",
+   "metadata": {},
+   "source": [
+    "## プロジェクトのファイルがコピーされていないことを確認する\n",
+    "\n",
+    "テストファイルが存在せず、エラーが出力されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be8a9df0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await run_lab_command(page, f'!cat {binderhub_test_filename}', 'No such file or directory')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0476866d",
+   "metadata": {},
+   "source": [
+    "## JupyterLabウィンドウを閉じる"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d2699e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await close_latest_page()\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06d85326",
+   "metadata": {},
+   "source": [
+    "## 「デフォルトストレージの内容をコピーする」チェックボックスをオンに戻す\n",
+    "\n",
+    "チェックボックスがオンになること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97ed858a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    checkbox = page.locator('//*[@data-test-copy-default-storage]')\n",
+    "    await expect(checkbox).not_to_be_checked(timeout=transition_timeout)\n",
+    "    await checkbox.click()\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b4e5d03",
+   "metadata": {},
+   "source": [
+    "## 基本イメージの「変更」をクリックする\n",
+    "\n",
+    "Dockerfileオプションが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "463a6307",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//*[@data-test-image-change]').click()\n",
+    "    await expect(page.locator(f'//*[@data-test-image-selection = \"{binderhub_dockerfile_option}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a37ea7c9",
+   "metadata": {},
+   "source": [
+    "## 「Dockerfileを用いたカスタムイメージ」をクリックする\n",
+    "\n",
+    "「Dockerfile」エディターが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "486ffef7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator(f'//*[@data-test-image-selection = \"{binderhub_dockerfile_option}\"]').click()\n",
+    "    await expect(page.locator('//h3[text() = \"Dockerfile\"]/../..//textarea')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4be444e0",
+   "metadata": {},
+   "source": [
+    "## 「Dockerfile」エディターにスクリプトを入力する\n",
+    "\n",
+    "入力内容が表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73f4f245",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    textarea = page.locator('//h3[text() = \"Dockerfile\"]/../..//textarea')\n",
+    "    await textarea.fill(dockerfile_custom_script)\n",
+    "    await textarea.press('Tab')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80706d5e",
+   "metadata": {},
+   "source": [
+    "## 「保存」をクリックする\n",
+    "\n",
+    "エラーメッセージが表示されないこと"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "264d0d25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await page.locator('//h3[text() = \"Dockerfile\"]/../..//button[text() = \"保存\"]').click()\n",
+    "    await asyncio.sleep(10)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "965a7c97",
+   "metadata": {},
+   "source": [
+    "## 「新しい解析環境を作成」をクリックする\n",
+    "\n",
+    "環境の起動を待つ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a41c71e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    popup_future = page.wait_for_event('popup', timeout=binderhub_launch_timeout)\n",
+    "    await page.locator('//*[@data-test-binderhub-launch]').click()\n",
+    "    popup = await popup_future\n",
+    "    return popup\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5be37547",
+   "metadata": {},
+   "source": [
+    "## JupyterLabが表示されていることを確認する"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e98a1ba9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@class = \"jp-LauncherCard\" and @title = \"Python 3 (ipykernel)\" and @data-category = \"Notebook\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e36b3068",
+   "metadata": {},
+   "source": [
+    "## プロジェクトのファイルがコピーされていることを確認する\n",
+    "\n",
+    "新規Notebookを作成し、テストファイルの内容が出力されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8ff0f5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    launcher_label = 'Python 3 (ipykernel)'\n",
+    "    launcher = page.locator(f'//*[@class = \"jp-LauncherCard\" and @title = \"{launcher_label}\" and @data-category = \"Notebook\"]')\n",
+    "    await expect(launcher).to_be_visible(timeout=transition_timeout)\n",
+    "    await launcher.click()\n",
+    "\n",
+    "    # Execution Indicator は、 ... でCollapseされ表示されない可能性がある\n",
+    "    try:\n",
+    "        await expect(page.locator('//*[contains(@class, \"jp-Notebook-ExecutionIndicator\") and @data-status=\"idle\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "        await asyncio.sleep(5)\n",
+    "    except:\n",
+    "        # Warning\n",
+    "        traceback.print_exc()\n",
+    "\n",
+    "    await run_lab_command(page, f'!cat {binderhub_test_filename}', binderhub_test_file_content)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a651be72",
+   "metadata": {},
+   "source": [
+    "## JupyterLabウィンドウを閉じる"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaf81f8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await close_latest_page()\n",
+    "\n",
+    "async def _step(page):\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91d84c49",
+   "metadata": {},
+   "source": [
+    "終了処理を実施する。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c589cc35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eea62443",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/テスト手順-local-BinderHubアドオン-停止中のBinderHubアドオン.ipynb
+++ b/テスト手順-local-BinderHubアドオン-停止中のBinderHubアドオン.ipynb
@@ -1,0 +1,533 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f226930",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from getpass import getpass\n",
+    "\n",
+    "rdm_url = None\n",
+    "idp_name_1 = None\n",
+    "idp_username_1 = None\n",
+    "idp_password_1 = None\n",
+    "\n",
+    "jupyterhub_username = None\n",
+    "jupyterhub_password = None\n",
+    "\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 60 * 1000\n",
+    "\n",
+    "project_name = None\n",
+    "\n",
+    "halted_hub = dict(\n",
+    "    binderhub_url=\"https://example.com\",\n",
+    "    binderhub_oauth_client_id=\"AAAA\",\n",
+    "    binderhub_oauth_client_secret=\"BBBB\",\n",
+    "    jupyterhub_url=\"https://example.net\",\n",
+    "    jupyterhub_oauth_client_id=\"XXXX\",\n",
+    "    jupyterhub_oauth_client_secret=\"YYYY\",\n",
+    "    jupyterhub_admin_api_token=\"YYYY\",\n",
+    "    jupyterhub_logout_url=\"https://example.net/hub/logout\",\n",
+    "    jupyterhub_max_servers=\"3\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aff8b10c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if rdm_url is None:\n",
+    "    rdm_url = input(prompt=f'RDM URL: ')\n",
+    "if idp_name_1 is None:\n",
+    "    idp_name_1 = input(prompt=f'IdP Name: ')\n",
+    "if idp_username_1 is None:\n",
+    "    idp_username_1 = input(prompt=f'Username for {idp_name_1}')\n",
+    "if idp_password_1 is None:\n",
+    "    idp_password_1 = getpass(prompt=f'Password for {idp_username_1}@{idp_name_1}')\n",
+    "if jupyterhub_username is None:\n",
+    "    jupyterhub_username = input(prompt='Username for JupyterHub')\n",
+    "if jupyterhub_password is None:\n",
+    "    jupyterhub_password = getpass(prompt=f'Password for {jupyterhub_username}@JupyterHub')\n",
+    "if project_name is None:\n",
+    "    project_name = datetime.now().strftime('TEST-BINDERHUB-%Y%m%d%H%M')\n",
+    "\n",
+    "project_url = None\n",
+    "project_created = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "886a2dac",
+   "metadata": {},
+   "source": [
+    "# BinderHubアドオン 停止中のBinderHubアドオン\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アカウント設定\n",
+    "- シナリオ名:  BinderHub停止中のBinderHubアドオン\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で1個作れる状態であること)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "772b2cca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35b4436c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "import pandas as pd\n",
+    "\n",
+    "import scripts.playwright\n",
+    "importlib.reload(scripts.playwright)\n",
+    "\n",
+    "from scripts.playwright import *\n",
+    "from scripts import grdm, jupyterhub\n",
+    "\n",
+    "await init_pw_context(close_on_fail=close_on_fail, last_path=default_result_path)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0da0d1cc",
+   "metadata": {},
+   "source": [
+    "## ウェブブラウザの新規プライベートウィンドウでLocal RDMトップページを表示する\n",
+    "\n",
+    "Local RDMトップページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "290bbecd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.goto(rdm_url, wait_until='networkidle')\n",
+    "    consent_button = page.locator('//button[text() = \"同意する\"]')\n",
+    "    if await consent_button.count():\n",
+    "        await consent_button.click()\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cab95b0",
+   "metadata": {},
+   "source": [
+    "## IdPを利用し、既存ユーザー1としてログインする\n",
+    "\n",
+    "Local RDMダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1afb958d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.login(page, idp_name_1, idp_username_1, idp_password_1, transition_timeout=transition_timeout)\n",
+    "    await grdm.expect_dashboard(page, transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6685c470",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードから「新規プロジェクト作成」をクリックする\n",
+    "\n",
+    "指定したプロジェクトが存在しない場合、新規プロジェクトが作成されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f36c5855",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_created\n",
+    "    project_created = await grdm.ensure_project_exists(page, project_name, transition_timeout=transition_timeout)\n",
+    "    if project_created:\n",
+    "        print(f'Created project: {project_name}')\n",
+    "    else:\n",
+    "        print(f'Project already exists: {project_name}')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0626a5ef",
+   "metadata": {},
+   "source": [
+    "## ダッシュボードのプロジェクト一覧から作成したプロジェクトをクリックする\n",
+    "\n",
+    "プロジェクトダッシュボードが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50c00268",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    global project_url\n",
+    "    await page.locator(f'//*[@data-test-dashboard-item-title and text() = \"{project_name}\"]').click()\n",
+    "    await expect(page.locator('//span[@id = \"nodeTitleEditable\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(page.locator('//a[text() = \"アドオン\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    project_url = page.url\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0c06d3c",
+   "metadata": {},
+   "source": [
+    "## BinderHubアドオンを有効化する\n",
+    "\n",
+    "アドオン利用規約の確認ダイアログが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcd602bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await grdm.enable_addon(page, 'GakuNin Federated Computing Services (Jupyter)', transition_timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0402f77c",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbfec0f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    await jupyterhub.login(page, jupyterhub_username, jupyterhub_password, transition_timeout)\n",
+    "    await jupyterhub.authorize(page, transition_timeout)\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f849fbb",
+   "metadata": {},
+   "source": [
+    "## 「BinderHubを追加」ボタンをクリックする\n",
+    "\n",
+    "BinderHubクライアント情報の設定ダイアログが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "355294b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    await page.locator('//a[text() = \"アドオン\"]').click()\n",
+    "    binder_entry = page.locator(f'//a[text() = \"{halted_hub[\"binderhub_url\"]}\"]')\n",
+    "    if await binder_entry.count():\n",
+    "        print('BinderHub entry already exists')\n",
+    "        return\n",
+    "    add_button = page.locator('//button[@href=\"#binderhubInputHost\"]')\n",
+    "    await add_button.click()\n",
+    "    await expect(page.locator('//input[@name = \"binderhub_url\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await page.locator('//input[@name = \"binderhub_url\"]').fill(halted_hub[\"binderhub_url\"])\n",
+    "    # Configure BinderHub OAuth\n",
+    "    await page.locator('//input[@name = \"binderhub_has_oauth_client\"]').check()\n",
+    "    await expect(page.locator('//input[@name = \"binderhub_has_oauth_client\"]')).to_be_checked(timeout=transition_timeout)\n",
+    "    await page.locator('//input[@name = \"binderhub_oauth_client_id\"]').fill(halted_hub[\"binderhub_oauth_client_id\"])\n",
+    "    await page.locator('//input[@name = \"binderhub_oauth_client_secret\"]').fill(halted_hub[\"binderhub_oauth_client_secret\"])\n",
+    "    # Configure JupyterHub OAuth\n",
+    "    await page.locator('//input[@name = \"jupyterhub_has_oauth_client\"]').check()\n",
+    "    await expect(page.locator('//input[@name = \"jupyterhub_has_oauth_client\"]')).to_be_checked(timeout=transition_timeout)\n",
+    "    await page.locator('//input[@name = \"jupyterhub_url\"]').fill(halted_hub[\"jupyterhub_url\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_oauth_client_id\"]').fill(halted_hub[\"jupyterhub_oauth_client_id\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_oauth_client_secret\"]').fill(halted_hub[\"jupyterhub_oauth_client_secret\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_admin_api_token\"]').fill(halted_hub[\"jupyterhub_admin_api_token\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_logout_url\"]').fill(halted_hub[\"jupyterhub_logout_url\"])\n",
+    "    await page.locator('//input[@name = \"jupyterhub_max_servers\"]').fill(halted_hub[\"jupyterhub_max_servers\"])\n",
+    "    # Tab to trigger any on-change events\n",
+    "    await page.locator('//input[@name = \"binderhub_url\"]').press('Tab')\n",
+    "    save_button = page.locator('//button[contains(@data-bind, \"hostCompleted\") and contains(text(), \"保存\")]')\n",
+    "    await expect(save_button).to_be_enabled(timeout=transition_timeout)\n",
+    "    await save_button.click()\n",
+    "    await expect(page.locator(f'//a[text() = \"{halted_hub[\"binderhub_url\"]}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f10608f",
+   "metadata": {},
+   "source": [
+    "## 追加したBinderHubのチェックボックスをクリックする\n",
+    "\n",
+    "Default BinderHub URL が追加したBinderHubのURLになること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "847b10ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    default_square = page.locator(f'//a[text() = \"{halted_hub[\"binderhub_url\"]}\"]/../..//i[contains(@class, \"fa-square\")]')\n",
+    "    if await default_square.count():\n",
+    "        await default_square.click()\n",
+    "        await expect(page.locator(f'//a[text() = \"{halted_hub[\"binderhub_url\"]}\"]/../..//i[contains(@class, \"fa-check-square\")]')).to_be_visible(timeout=transition_timeout)\n",
+    "    else:\n",
+    "        print('BinderHub already selected')\n",
+    "\n",
+    "await run_pw(_step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb7e10e0",
+   "metadata": {},
+   "source": [
+    "## プロジェクトダッシュボードの上部メニューから「解析」をクリックする\n",
+    "\n",
+    "BinderHubアドオンページが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e4013a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "async def _step(page):\n",
+    "    await page.locator('//a[contains(text(), \"解析\")]').click()\n",
+    "    await expect(page.locator('//*[@data-test-binderhub-launch]')).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "473ae23c",
+   "metadata": {},
+   "source": [
+    "## 解析機能ページがBinderHub停止中を示唆していることを確かめる\n",
+    "\n",
+    "BinderHub停止中を案内するバナーが表示されること、解析環境を作成するボタンが無効状態となっていること\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54a033fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    launch_button = page.locator('//*[@data-test-binderhub-launch]')\n",
+    "    await expect(launch_button).to_be_disabled(timeout=transition_timeout)\n",
+    "    banner = page.locator('//p[contains(text(), \"選択されたJupyterHubは現在停止中です。現在、新規の解析環境は作成できません。\")]')\n",
+    "    await expect(banner).to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "105b6f46",
+   "metadata": {},
+   "source": [
+    "## ホスト選択ダイアログを開くボタンをクリックする\n",
+    "\n",
+    "ホスト選択ダイアログが表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab114622",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    open_host_selector = page.locator('//*[@data-test-open-host-selector-dialogue]')\n",
+    "    await expect(open_host_selector).to_be_visible(timeout=transition_timeout)\n",
+    "    await open_host_selector.click()\n",
+    "    await expect(page.locator('//*[text() = \"ホスト選択\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    \n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5c2729e",
+   "metadata": {},
+   "source": [
+    "## 初期設定されるホストを選択する\n",
+    "\n",
+    "ホスト選択ダイアログが閉じられること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d2b23b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    topmost = page.locator('//*[@data-test-host-selection-option]').nth(0)\n",
+    "    await expect(topmost).to_be_visible(timeout=transition_timeout)\n",
+    "    await topmost.click()\n",
+    "    await page.locator('//*[@data-test-host-selector-dialogue-ok]').click()\n",
+    "    await expect(page.locator('//*[text() = \"ホスト選択\"]')).not_to_be_visible(timeout=transition_timeout)\n",
+    "    \n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ffb82ea",
+   "metadata": {},
+   "source": [
+    "## 解析機能ページがBinderHub停止中を示唆していないことを確かめる\n",
+    "\n",
+    "BinderHub停止中を案内するバナーが非表示となること、解析環境作成ボタンが有効になっていること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82a9ad18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _step(page):\n",
+    "    launch_button = page.locator('//*[@data-test-binderhub-launch]')\n",
+    "    await expect(launch_button).to_be_enabled(timeout=transition_timeout)\n",
+    "    banner = page.locator('//p[contains(text(), \"選択されたJupyterHubは現在停止中です。現在、新規の解析環境は作成できません。\")]')\n",
+    "    await expect(banner).not_to_be_visible(timeout=transition_timeout)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0d9d37f",
+   "metadata": {},
+   "source": [
+    "終了処理を実施する。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9da116b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await finish_pw_context()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a68c393",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/取りまとめ-local-BinderHubアドオン.ipynb
+++ b/取りまとめ-local-BinderHubアドオン.ipynb
@@ -1,0 +1,1038 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c11c1bc4-80b2-4ddd-aabc-5ce74e190463",
+   "metadata": {
+    "deletable": true,
+    "editable": true,
+    "lc_cell_meme": {
+     "current": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-15-fa46-c0e7-3185-bcb1-eb64-ff1f-e88c-0910-7923-180d",
+     "history": [
+      {
+       "current": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-8-490a-05fb-01ac-29c3-d4dc-cf29-6b30-a674",
+       "previous": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658"
+      },
+      {
+       "current": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-8-490a-05fb-01ac-29c3-d4dc-cf29-6b30-a674",
+       "previous": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658"
+      }
+     ],
+     "next": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-12-9043-4ba3-5193-3fce-7040-afde-7319-156a-b08a-efc8",
+     "previous": "05cdacf8-3a56-11f0-8d62-b672e09b3688"
+    },
+    "pinnedOutputTabIndex": 0,
+    "run_through_control": {
+     "frozen": false,
+     "read_only": false
+    },
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from getpass import getpass\n",
+    "\n",
+    "rdm_url = None\n",
+    "idp_name_1 = None\n",
+    "idp_username_1 = None\n",
+    "idp_password_1 = None\n",
+    "\n",
+    "jupyterhub_username = None\n",
+    "jupyterhub_password = None\n",
+    "\n",
+    "project_name_prefix = datetime.now().strftime('TEST-BINDERHUB-%Y%m%d%H%M')\n",
+    "default_result_path = None\n",
+    "close_on_fail = False\n",
+    "transition_timeout = 60 * 1000\n",
+    "binderhub_launch_timeout = 30 * 60 * 1000\n",
+    "skip_failed_test = True\n",
+    "skip_preview_check = False\n",
+    "exclude_notebooks = []\n",
+    "binderhub_binderhub_url = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98f29bed-b81f-4ebf-b015-4cd4853bb0be",
+   "metadata": {
+    "deletable": true,
+    "lc_cell_meme": {
+     "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-13-4ba3-5193-3fce-7040-afde-7319-156a-b08a-efc8-3530",
+     "execution_end_time": "2025-04-02T06:25:57.346Z",
+     "history": [
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-2-a21c-c06b"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "a0674b68-0c3c-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-2-a21c-c06b"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "d95d6308-0c3c-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-2-a21c-c06b"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "a8832c1c-0c3d-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-2-a21c-c06b"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "e7480d50-0c3d-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-2-a21c-c06b"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-2-a21c-c06b"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-2-a21c-c06b"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-3-a21c-c06b-54e5"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f93f2d46-0c46-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-3-a21c-c06b-54e5"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "3295fed4-0c48-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-3-a21c-c06b-54e5"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "6a84eba0-0c4a-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-3-a21c-c06b-54e5"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "6d481ba6-0c53-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-3-a21c-c06b-54e5"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "221c4f0a-0c56-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-3-a21c-c06b-54e5"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "19d7ea5a-0c5d-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-3-a21c-c06b-54e5"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "377594ca-0c6e-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-3-3215-63a8-9043",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-3-a21c-c06b-54e5"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-4-3215-63a8-9043-4ba3",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-4-4202-aef0-78b6-5218",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-5-a21c-c06b-54e5-e070-ec83"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-7-3215-63a8-9043-4ba3-5193-3fce-7040",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-5-4202-aef0-78b6-5218-939f",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-6-a21c-c06b-54e5-e070-ec83-fa46"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-8-3215-63a8-9043-4ba3-5193-3fce-7040-afde",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-8-4202-aef0-78b6-5218-939f-7c1f-36a3-561d",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-9-a21c-c06b-54e5-e070-ec83-fa46-c0e7-3185-bcb1"
+      },
+      {
+       "current": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-12-9043-4ba3-5193-3fce-7040-afde-7319-156a-b08a-efc8",
+       "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-9-4202-aef0-78b6-5218-939f-7c1f-36a3-561d-61b6",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-10-a21c-c06b-54e5-e070-ec83-fa46-c0e7-3185-bcb1-eb64"
+      }
+     ],
+     "next": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-13-5218-939f-7c1f-36a3-561d-61b6-8267-4a88-1c97-cfab",
+     "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-14-ec83-fa46-c0e7-3185-bcb1-eb64-ff1f-e88c-0910-7923"
+    },
+    "pinnedOutputTabIndex": 0,
+    "run_through_control": {
+     "frozen": false,
+     "read_only": false
+    },
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if rdm_url is None:\n",
+    "    rdm_url = input(prompt=f'RDM URL: ')\n",
+    "if idp_name_1 is None:\n",
+    "    idp_name_1 = input(prompt=f'IdP Name: ')\n",
+    "if idp_username_1 is None:\n",
+    "    idp_username_1 = input(prompt=f'Username for {idp_name_1}: ')\n",
+    "if idp_password_1 is None:\n",
+    "    idp_password_1 = getpass(prompt=f'Password for {idp_username_1}@{idp_name_1}: ')\n",
+    "if jupyterhub_username is None:\n",
+    "    jupyterhub_username = input(prompt='Username for JupyterHub')\n",
+    "if jupyterhub_password is None:\n",
+    "    jupyterhub_password = getpass(prompt=f'Password for {jupyterhub_username}@JupyterHub')\n",
+    "(rdm_url, idp_name_1, idp_username_1, jupyterhub_username)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97683f65-7f21-419d-8c40-28cca14c5f08",
+   "metadata": {
+    "deletable": true,
+    "lc_cell_meme": {
+     "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-14-939f-7c1f-36a3-561d-61b6-8267-4a88-1c97-cfab-d694",
+     "execution_end_time": "2025-04-02T06:25:59.737Z",
+     "history": [
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-9-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-2-a21c-c06b"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-9-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-9-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-9-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-10-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "next": "a72e1754-0c48-11f0-98e9-5e0a5654d7bd",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0",
+       "next": "c31532b8-0c48-11f0-98e9-5e0a5654d7bd",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-4-4202-aef0-78b6-5218",
+       "next": "a72e1754-0c48-11f0-98e9-5e0a5654d7bd",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-1-3215"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-4-4202-aef0-78b6-5218",
+       "next": "a72e1754-0c48-11f0-98e9-5e0a5654d7bd-2-ce6c-01ad",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-3-3215-63a8-9043"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-5-4202-aef0-78b6-5218-939f",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-12-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11-50c2-120c",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-3-3215-63a8-9043"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-8-4202-aef0-78b6-5218-939f-7c1f-36a3-561d",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-13-4556-863e-9370-b5f5-e658-7a0b-7f11-50c2-120c-62e9",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-4-3215-63a8-9043-4ba3"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-9-4202-aef0-78b6-5218-939f-7c1f-36a3-561d-61b6",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-16-b5f5-e658-7a0b-7f11-50c2-120c-62e9-f0ed-0032-2c57",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-7-3215-63a8-9043-4ba3-5193-3fce-7040"
+      },
+      {
+       "current": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-13-5218-939f-7c1f-36a3-561d-61b6-8267-4a88-1c97-cfab",
+       "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-17-e658-7a0b-7f11-50c2-120c-62e9-f0ed-0032-2c57-2457",
+       "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-8-3215-63a8-9043-4ba3-5193-3fce-7040-afde"
+      }
+     ],
+     "next": "8b5ce66e-80d5-11ed-95e1-0242ac120004-21-120c-62e9-f0ed-0032-2c57-2457-0051-5baf-1381-665a",
+     "previous": "9a6a67cc-0c28-11f0-98e9-5e0a5654d7bd-12-9043-4ba3-5193-3fce-7040-afde-7319-156a-b08a-efc8"
+    },
+    "pinnedOutputTabIndex": 0,
+    "run_through_control": {
+     "frozen": false,
+     "read_only": false
+    },
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "work_dir = tempfile.mkdtemp()\n",
+    "if default_result_path is None:\n",
+    "    default_result_path = work_dir\n",
+    "work_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ad1e5b4-e544-43b9-9afa-b6fd7ece8584",
+   "metadata": {
+    "deletable": true,
+    "editable": true,
+    "lc_cell_meme": {
+     "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-22-62e9-f0ed-0032-2c57-2457-0051-5baf-1381-665a-d5e9",
+     "history": [
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-1-cb1b",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004",
+       "previous": null
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-2-cb1b-42bc",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-1-490a",
+       "previous": null
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-3-cb1b-42bc-e44d",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-2-490a-05fb",
+       "previous": null
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-4-cb1b-42bc-e44d-4556",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-3-490a-05fb-01ac",
+       "previous": null
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-5-cb1b-42bc-e44d-4556-863e",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-4-490a-05fb-01ac-29c3",
+       "previous": null
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-6-cb1b-42bc-e44d-4556-863e-9370",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-5-490a-05fb-01ac-29c3-d4dc",
+       "previous": null
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-7-cb1b-42bc-e44d-4556-863e-9370-b5f5",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-6-490a-05fb-01ac-29c3-d4dc-cf29",
+       "previous": null
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-7-490a-05fb-01ac-29c3-d4dc-cf29-6b30",
+       "previous": null
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-8-490a-05fb-01ac-29c3-d4dc-cf29-6b30-a674",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-8-490a-05fb-01ac-29c3-d4dc-cf29-6b30-a674",
+       "previous": "0c7d1c72-0c26-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "8b5ce6a0-80d5-11ed-95e1-0242ac120004-8-490a-05fb-01ac-29c3-d4dc-cf29-6b30-a674",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "8b5ce6e6-80d5-11ed-95e1-0242ac120004-8-cf3f-b3ef-db35-57ad-2bcf-ffc2-105c-69a6",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "8b5ce704-80d5-11ed-95e1-0242ac120004-8-134a-19fd-8302-4b9a-fe94-8416-c02c-3d66",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "4a2d93ba-575c-11ee-879c-cee8484f477d-7-ce15-af72-2e99-2376-ed5c-8317-0981",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "ac9f5680-9be1-11ef-bec6-b6d4434572e8-3-0c61-b7da-7291",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "8b5ce722-80d5-11ed-95e1-0242ac120004-8-ba9b-f235-19a9-23b6-7145-b64a-6dfb-09dd",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-8-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-9-2295-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92",
+       "previous": "f05363a8-0c25-11f0-98e9-5e0a5654d7bd-1-a21c"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-9-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-9-2295-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-10-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-10-2295-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92-f25a",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-10-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-10-2295-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92-f25a",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-10-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-10-2295-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92-f25a",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-1-4202"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-10-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-11-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92-f25a-44f7",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-2-4202-aef0"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-10-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-11-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92-f25a-44f7",
+       "previous": "a72e1754-0c48-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-10-cb1b-42bc-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-11-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92-f25a-44f7",
+       "previous": "3bd0c974-0c49-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-12-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11-50c2-120c",
+       "next": "8b5ce740-80d5-11ed-95e1-0242ac120004-11-9f93-ce95-2df2-6ce8-e56d-28e9-7a4e-fd92-f25a-44f7",
+       "previous": "a72e1754-0c48-11f0-98e9-5e0a5654d7bd"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-12-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11-50c2-120c",
+       "next": "7258c5f6-0f8b-11f0-935e-6e323efef16c",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-4-4202-aef0-78b6-5218"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-12-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11-50c2-120c",
+       "next": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-4-4202-aef0-78b6-5218"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-13-4556-863e-9370-b5f5-e658-7a0b-7f11-50c2-120c-62e9",
+       "next": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-4-4202-aef0-78b6-5218"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-16-b5f5-e658-7a0b-7f11-50c2-120c-62e9-f0ed-0032-2c57",
+       "next": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-1-b213",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-5-4202-aef0-78b6-5218-939f"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-17-e658-7a0b-7f11-50c2-120c-62e9-f0ed-0032-2c57-2457",
+       "next": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-4-b213-00e1-d99a-d244",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-8-4202-aef0-78b6-5218-939f-7c1f-36a3-561d"
+      },
+      {
+       "current": "8b5ce66e-80d5-11ed-95e1-0242ac120004-21-120c-62e9-f0ed-0032-2c57-2457-0051-5baf-1381-665a",
+       "next": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-5-b213-00e1-d99a-d244-936b",
+       "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-9-4202-aef0-78b6-5218-939f-7c1f-36a3-561d-61b6"
+      }
+     ],
+     "next": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-9-b213-00e1-d99a-d244-936b-b9fe-e496-7385-6aa6",
+     "previous": "4f1d97fa-0c26-11f0-98e9-5e0a5654d7bd-13-5218-939f-7c1f-36a3-561d-61b6-8267-4a88-1c97-cfab"
+    },
+    "pinnedOutputTabIndex": 0,
+    "run_through_control": {
+     "frozen": false,
+     "read_only": false
+    },
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# GakuNinRDM 総合テスト [BinderHubアドオン]\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アドオン操作\n",
+    "- シナリオ名: *\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d89a6c3-cb47-4206-b2ce-5527260dd3e9",
+   "metadata": {
+    "deletable": true,
+    "lc_cell_meme": {
+     "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-13-ced2-b6ea-11de-e027-5ced-0939-f364-e8a5-98ea-129a",
+     "execution_end_time": "2025-04-02T06:31:11.748Z",
+     "history": [
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd",
+       "next": "fc1e9000-ecda-11ef-b381-0242ac120006-8-ad5a-1453-986a-418b-269a-3f21-466e-058e",
+       "previous": "8b87efd0-f991-11ef-a92d-0242ac120006-5-ccde-2dab-8cb6-87a2-145c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-1-c85a",
+       "next": "c9853da6-0c6f-11f0-98e9-5e0a5654d7bd",
+       "previous": "8b87efd0-f991-11ef-a92d-0242ac120006-5-ccde-2dab-8cb6-87a2-145c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "c9853da6-0c6f-11f0-98e9-5e0a5654d7bd-1-f3a3",
+       "previous": "8b87efd0-f991-11ef-a92d-0242ac120006-6-ccde-2dab-8cb6-87a2-145c-a1d6"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "7258c5f6-0f8b-11f0-935e-6e323efef16c",
+       "previous": "8b5ce66e-80d5-11ed-95e1-0242ac120004-12-e44d-4556-863e-9370-b5f5-e658-7a0b-7f11-50c2-120c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "7258c5f6-0f8b-11f0-935e-6e323efef16c",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "e49811c6-0f8b-11f0-935e-6e323efef16c",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "9954a6fc-0c70-11f0-98e9-5e0a5654d7bd-3-f4b2-32da-b588",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "9954a6fc-0c70-11f0-98e9-5e0a5654d7bd-3-f4b2-32da-b588",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "3e836c18-0c75-11f0-b991-feb16f56f93e-3-b008-e8d0-3f9b",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "1945ee16-0f8c-11f0-935e-6e323efef16c",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-3-c85a-d8bf-8dea",
+       "next": "1945ee16-0f8c-11f0-935e-6e323efef16c",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-4-c85a-d8bf-8dea-ced2",
+       "next": "1945ee16-0f8c-11f0-935e-6e323efef16c-1-2c1c",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-7-c85a-d8bf-8dea-ced2-b6ea-11de-e027",
+       "next": "1945ee16-0f8c-11f0-935e-6e323efef16c-2-2c1c-4f08",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-1-b213"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-7-c85a-d8bf-8dea-ced2-b6ea-11de-e027",
+       "next": "e4ebb1f2-191b-11f0-ad36-668cb6ddd6b0",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-4-b213-00e1-d99a-d244"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-8-c85a-d8bf-8dea-ced2-b6ea-11de-e027-5ced",
+       "next": "1945ee16-0f8c-11f0-935e-6e323efef16c-5-2c1c-4f08-40b5-cf6e-9e08",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-4-b213-00e1-d99a-d244"
+      },
+      {
+       "current": "8af0ac06-0c6f-11f0-98e9-5e0a5654d7bd-12-8dea-ced2-b6ea-11de-e027-5ced-0939-f364-e8a5-98ea",
+       "next": "1945ee16-0f8c-11f0-935e-6e323efef16c-6-2c1c-4f08-40b5-cf6e-9e08-8d48",
+       "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-5-b213-00e1-d99a-d244-936b"
+      }
+     ],
+     "next": "1945ee16-0f8c-11f0-935e-6e323efef16c-10-2c1c-4f08-40b5-cf6e-9e08-8d48-f057-5c33-2714-dcb0",
+     "previous": "b4bb8a0a-0f8b-11f0-935e-6e323efef16c-9-b213-00e1-d99a-d244-936b-b9fe-e496-7385-6aa6"
+    },
+    "pinnedOutputTabIndex": 0,
+    "run_through_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "import os\n",
+    "import papermill as pm\n",
+    "from scripts.papermillHelpers import gen_run_notebook\n",
+    "\n",
+    "def make_result_dir(base_path):\n",
+    "    result_dir = os.path.join(base_path, 'notebooks')\n",
+    "    os.makedirs(result_dir, exist_ok=True)\n",
+    "    return result_dir\n",
+    "\n",
+    "result_dir = make_result_dir(default_result_path)\n",
+    "\n",
+    "run_notebook = gen_run_notebook(\n",
+    "    result_dir,\n",
+    "    transition_timeout,\n",
+    "    dict(\n",
+    "        rdm_url=rdm_url,\n",
+    "        idp_name_1=idp_name_1,\n",
+    "        idp_username_1=idp_username_1,\n",
+    "        idp_password_1=idp_password_1,\n",
+    "        jupyterhub_username=jupyterhub_username,\n",
+    "        jupyterhub_password=jupyterhub_password,\n",
+    "        transition_timeout=transition_timeout,\n",
+    "        binderhub_launch_timeout=binderhub_launch_timeout,\n",
+    "    ),\n",
+    "    skip_failed_test,\n",
+    "    exclude_notebooks,\n",
+    ")\n",
+    "\n",
+    "result_notebooks = []\n",
+    "result_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "133f4114",
+   "metadata": {},
+   "source": [
+    "# プロジェクトに対するBinderHubアドオンの登録\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アカウント設定\n",
+    "- シナリオ名: プロジェクトへの有効化\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で6個作れる状態であること)、BinderHub OAuthクライアント情報\n",
+    "- 事前条件: なし"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af1d3994",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_notebooks.append(\n",
+    "    run_notebook(\n",
+    "        'テスト手順-local-BinderHubアドオン-アドオン追加.ipynb',\n",
+    "        dict(\n",
+    "            project_name=f'{project_name_prefix}-add-binderhub-addon',\n",
+    "            binderhub_binderhub_url=binderhub_binderhub_url,\n",
+    "        ),\n",
+    "    )\n",
+    ")\n",
+    "result_notebooks[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9075d8fb",
+   "metadata": {},
+   "source": [
+    "# BinderHubアドオン repo2docker による解析環境の起動\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アドオン操作\n",
+    "- シナリオ名: repo2docker基本イメージを使った解析環境の起動\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で5個作れる状態であること)、BinderHub OAuthクライアント情報\n",
+    "- 事前条件: なし"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56af6c97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_notebooks.append(\n",
+    "    run_notebook(\n",
+    "        'テスト手順-local-BinderHubアドオン-repo2docker.ipynb',\n",
+    "        dict(\n",
+    "            project_name=f'{project_name_prefix}-repo2docker',\n",
+    "        ),\n",
+    "    )\n",
+    ")\n",
+    "result_notebooks[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d48392b8",
+   "metadata": {},
+   "source": [
+    "# BinderHubアドオン Dockerfile による解析環境の起動\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アドオン操作\n",
+    "- シナリオ名: Dockerfile基本イメージを使った解析環境の起動\n",
+    "- 分類: BinderHub, アカウント設定\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で4個作れる状態であること)、BinderHub OAuthクライアント情報\n",
+    "- 事前条件: なし"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c1efc22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_notebooks.append(\n",
+    "    run_notebook(\n",
+    "        'テスト手順-local-BinderHubアドオン-Dockerfile.ipynb',\n",
+    "        dict(\n",
+    "            project_name=f'{project_name_prefix}-Dockerfile',\n",
+    "        )\n",
+    "    ),\n",
+    ")\n",
+    "result_notebooks[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e75c3c3",
+   "metadata": {},
+   "source": [
+    "# BinderHubアドオン デフォルトストレージのコピー制御\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アドオン操作\n",
+    "- シナリオ名: デフォルトストレージのコピー制御\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で3個作れる状態であること)、BinderHub OAuthクライアント情報\n",
+    "- 事前条件: なし"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "237d4b68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_notebooks.append(\n",
+    "    run_notebook(\n",
+    "        'テスト手順-local-BinderHubアドオン-デフォルトストレージのコピー制御.ipynb',\n",
+    "        dict(\n",
+    "            project_name=f'{project_name_prefix}-default-storage-copy-control',\n",
+    "        ),\n",
+    "    )\n",
+    ")\n",
+    "result_notebooks[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f61bf05",
+   "metadata": {},
+   "source": [
+    "# BinderHubアドオン 停止中のBinderHubアドオン\n",
+    "\n",
+    "- サブシステム名: アドオン\n",
+    "- ページ/アドオン: BinderHub\n",
+    "- 機能分類: アカウント設定\n",
+    "- シナリオ名:  BinderHub停止中のBinderHubアドオン\n",
+    "- 用意するテストデータ: URL一覧、アカウント(既存ユーザー1: Local RDM + JupyterHub, Local RDMは全てプロフィールを埋めていること / JupyterHubはサーバが追加で1個作れる状態であること)、BinderHub OAuthクライアント情報\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "650beba4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_notebooks.append(\n",
+    "    run_notebook(\n",
+    "        'テスト手順-local-BinderHubアドオン-停止中のBinderHubアドオン.ipynb',\n",
+    "        dict(\n",
+    "            project_name=f'{project_name_prefix}-halted-binderhub',\n",
+    "        ),\n",
+    "    )\n",
+    ")\n",
+    "result_notebooks[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5cc83a0-92f4-43f4-92d4-0788ef8f838e",
+   "metadata": {
+    "lc_cell_meme": {
+     "current": "49f48492-1c24-11f0-baf6-eaf1011eb67f-6-e4e3-bf8a-77f2-63dd-03e6-1500",
+     "execution_end_time": "2025-04-18T07:11:11.384Z",
+     "history": [
+      {
+       "current": "49f48492-1c24-11f0-baf6-eaf1011eb67f-5-e4e3-bf8a-77f2-63dd-03e6",
+       "next": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-7-1403-a376-dc1e-e116-9124-5c27-100b",
+       "previous": "9954a6fc-0c70-11f0-98e9-5e0a5654d7bd-9-f4b2-32da-b588-2ea3-c289-53e5-31c4-7b04-2eff"
+      }
+     ],
+     "next": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-11-a376-dc1e-e116-9124-5c27-100b-e3ef-d2c3-e955-016d",
+     "previous": "9954a6fc-0c70-11f0-98e9-5e0a5654d7bd-13-2ea3-c289-53e5-31c4-7b04-2eff-2c6e-2ac3-1cfb-6be8"
+    },
+    "pinnedOutputTabIndex": 0
+   },
+   "source": [
+    "終了処理を実施。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14ba6005-25df-40b0-a422-5904229346ea",
+   "metadata": {
+    "deletable": true,
+    "editable": true,
+    "lc_cell_meme": {
+     "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-12-dc1e-e116-9124-5c27-100b-e3ef-d2c3-e955-016d-1c7b",
+     "history": [
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "d9d1b1ac-ba69-11ee-be42-76dc322c86bf-7-4788-8a30-7d73-49da-50cd-ddaa-9795",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-8-bd88-6497-d40c-e2d4-e257-f333-e27b-a86e"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "a0be15fa-cfbc-11ee-aac4-e614fd240312-5-d8db-2f52-2d72-4f01-7bae",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-8-bd88-6497-d40c-e2d4-e257-f333-e27b-a86e"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd",
+       "next": "be5ca7a6-cfbd-11ee-aac4-e614fd240312-5-2859-6def-5a16-eab4-6380",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-8-bd88-6497-d40c-e2d4-e257-f333-e27b-a86e"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-1-1403",
+       "next": "dcea328c-cfbe-11ee-aac4-e614fd240312-5-2457-4dd6-1c26-a538-0927",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-8-bd88-6497-d40c-e2d4-e257-f333-e27b-a86e"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-2-1403-a376",
+       "next": "dcea328c-cfbe-11ee-aac4-e614fd240312-6-2457-4dd6-1c26-a538-0927-fec0",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-9-bd88-6497-d40c-e2d4-e257-f333-e27b-a86e-3653"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-2-1403-a376",
+       "next": "dcea328c-cfbe-11ee-aac4-e614fd240312-6-2457-4dd6-1c26-a538-0927-fec0",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-9-bd88-6497-d40c-e2d4-e257-f333-e27b-a86e-3653"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-2-1403-a376",
+       "next": "dcea328c-cfbe-11ee-aac4-e614fd240312-6-2457-4dd6-1c26-a538-0927-fec0",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-9-bd88-6497-d40c-e2d4-e257-f333-e27b-a86e-3653"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-4-1403-a376-dc1e-e116",
+       "next": "dcea328c-cfbe-11ee-aac4-e614fd240312-7-2457-4dd6-1c26-a538-0927-fec0-3901",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-10-bd88-6497-d40c-e2d4-e257-f333-e27b-a86e-3653-5c2a"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-4-1403-a376-dc1e-e116",
+       "next": "cf79f6c6-0422-11ef-b901-9ee4ca18f90f-9-3228-42c1-7841-354c-51c4-ea5d-d982-3358-01df",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-12-d40c-e2d4-e257-f333-e27b-a86e-3653-5c2a-fa15-d3c9"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-4-1403-a376-dc1e-e116",
+       "next": "d270a640-0422-11ef-b901-9ee4ca18f90f-8-7a83-35a2-e666-ef9d-6e01-3bb7-30fc-7a42",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-12-d40c-e2d4-e257-f333-e27b-a86e-3653-5c2a-fa15-d3c9"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-4-1403-a376-dc1e-e116",
+       "next": "88d5931c-0434-11ef-b901-9ee4ca18f90f-9-656a-f4ab-e3d8-0fc4-8f9b-dfcc-a95f-af4d-9c46",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-12-d40c-e2d4-e257-f333-e27b-a86e-3653-5c2a-fa15-d3c9"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-4-1403-a376-dc1e-e116",
+       "next": "939d9c60-e7a8-11ef-8804-e664e9f91ae7-1-61df",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-12-d40c-e2d4-e257-f333-e27b-a86e-3653-5c2a-fa15-d3c9"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-4-1403-a376-dc1e-e116",
+       "next": "8c06187c-0434-11ef-b901-9ee4ca18f90f-8-7549-a108-3151-df1a-9436-0956-114e-4777",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-12-d40c-e2d4-e257-f333-e27b-a86e-3653-5c2a-fa15-d3c9"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-6-1403-a376-dc1e-e116-9124-5c27",
+       "next": "13c35e24-73c9-11ef-b0d7-cee2f9bc9ae0-2-4d24-05bb",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-12-d40c-e2d4-e257-f333-e27b-a86e-3653-5c2a-fa15-d3c9"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-7-1403-a376-dc1e-e116-9124-5c27-100b",
+       "next": "7e8f35b8-1151-11f0-b2ca-76718da5da48-2-f82d-bed3",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-14-e257-f333-e27b-a86e-3653-5c2a-fa15-d3c9-8f37-c6be"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-7-1403-a376-dc1e-e116-9124-5c27-100b",
+       "next": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-9-1403-a376-dc1e-51a1-47bb-3e03-b84f-4b83-212e",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-15-f333-e27b-a86e-3653-5c2a-fa15-d3c9-8f37-c6be-0edc"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-7-1403-a376-dc1e-e116-9124-5c27-100b",
+       "next": "e49811c6-0f8b-11f0-935e-6e323efef16c-5-0919-5415-28e2-399c-c26b",
+       "previous": "0d153210-80d6-11ed-95e1-0242ac120004-15-f333-e27b-a86e-3653-5c2a-fa15-d3c9-8f37-c6be-0edc"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-7-1403-a376-dc1e-e116-9124-5c27-100b",
+       "next": "e49811c6-0f8b-11f0-935e-6e323efef16c-5-0919-5415-28e2-399c-c26b",
+       "previous": "9954a6fc-0c70-11f0-98e9-5e0a5654d7bd-9-f4b2-32da-b588-2ea3-c289-53e5-31c4-7b04-2eff"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-7-1403-a376-dc1e-e116-9124-5c27-100b",
+       "next": "e49811c6-0f8b-11f0-935e-6e323efef16c-5-0919-5415-28e2-399c-c26b",
+       "previous": "49f48492-1c24-11f0-baf6-eaf1011eb67f"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-7-1403-a376-dc1e-e116-9124-5c27-100b",
+       "next": "e49811c6-0f8b-11f0-935e-6e323efef16c-5-0919-5415-28e2-399c-c26b",
+       "previous": "49f48492-1c24-11f0-baf6-eaf1011eb67f"
+      },
+      {
+       "current": "41ca8840-0c28-11f0-98e9-5e0a5654d7bd-11-a376-dc1e-e116-9124-5c27-100b-e3ef-d2c3-e955-016d",
+       "next": "e49811c6-0f8b-11f0-935e-6e323efef16c-5-0919-5415-28e2-399c-c26b",
+       "previous": "49f48492-1c24-11f0-baf6-eaf1011eb67f-1-e4e3"
+      }
+     ],
+     "next": "e49811c6-0f8b-11f0-935e-6e323efef16c-9-0919-5415-28e2-399c-c26b-0541-36c1-58c6-f5f3",
+     "previous": "49f48492-1c24-11f0-baf6-eaf1011eb67f-5-e4e3-bf8a-77f2-63dd-03e6"
+    },
+    "pinnedOutputTabIndex": 0,
+    "run_through_control": {
+     "frozen": false,
+     "read_only": false
+    },
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!rm -fr {work_dir}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  },
+  "lc_notebook_meme": {
+   "current": "efecb6ea-0f8a-11f0-935e-6e323efef16c",
+   "lc_server_signature": {
+    "current": {
+     "notebook_dir": "/home/jovyan",
+     "notebook_path": "/取りまとめ-BinderHub-BinderHub.ipynb",
+     "signature_id": "1a2a1530-3284-11f0-89c3-c629d0b175e3"
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/結合試験-実行.ipynb
+++ b/結合試験-実行.ipynb
@@ -711,6 +711,7 @@
     "skip_erad_completion_test = False\n",
     "skip_admin = False\n",
     "skip_binderhub = False\n",
+    "skip_local_binderhub = False\n",
     "\n",
     "storages_oauth = [\n",
     "    {'id': 'dropbox', 'name': 'Dropbox'},\n",
@@ -761,7 +762,11 @@
     "\n",
     "# BinderHubアドオンのテスト\n",
     "# アドオン追加テストにおいて追加するBinderHubの情報\n",
-    "binderhub_binderhub_url = 'https://example.com/binderhub'"
+    "binderhub_binderhub_url = 'https://example.com/binderhub'\n",
+    "# ローカルでのBinderHubアドオンのテスト\n",
+    "# JupyterHubのユーザ情報\n",
+    "jupyterhub_username = None\n",
+    "jupyterhub_password = None"
    ]
   },
   {
@@ -4047,6 +4052,35 @@
    "source": [
     "if not skip_binderhub:\n",
     "    result_notebooks.append(run_notebook(result_dir, '取りまとめ-BinderHub-BinderHubアドオン.ipynb', binderhub_binderhub_url=binderhub_binderhub_url))\n",
+    "\n",
+    "result_notebooks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc24a05c",
+   "metadata": {},
+   "source": [
+    "## ローカル環境でのBinderHubアドオン関連テスト"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e880b02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not skip_local_binderhub:\n",
+    "    result_notebooks.append(\n",
+    "        run_notebook(\n",
+    "            result_dir,\n",
+    "            '取りまとめ-local-BinderHubアドオン.ipynb',\n",
+    "            binderhub_binderhub_url=binderhub_binderhub_url,\n",
+    "            jupyterhub_username=jupyterhub_username,\n",
+    "            jupyterhub_password=jupyterhub_password,\n",
+    "        )\n",
+    "    )\n",
     "\n",
     "result_notebooks"
    ]


### PR DESCRIPTION
## Purpose

フロントエンド(RDM-ember-osf-web)などの修正をリリース前に検証する用途には本番環境向けテストでは不便なため、既存の「テスト手順-BinderHub-BinderHubアドオン-*」と同一の観点を検証するテスト群を、本番環境ではなくローカルで起動したRDM-osf.ioに対してテストするテスト群を追加する。

## Changes

- 新規テスト手順ノートブック
  - `テスト手順-local-BinderHubアドオン-アドオン追加.ipynb`
  - `テスト手順-local-BinderHubアドオン-repo2docker.ipynb`
  - `テスト手順-local-BinderHubアドオン-Dockerfile.ipynb`
  - `テスト手順-local-BinderHubアドオン-デフォルトストレージのコピー制御.ipynb`
  - `テスト手順-local-BinderHubアドオン-停止中のBinderHubアドオン.ipynb`
- 新規取りまとめノートブック
   - `取りまとめ-local-BinderHubアドオン.ipynb`
- 新規ヘルパーモジュール
  - `scripts/jupyterhub.py` -- ローカルBinderHubアドオンではJupyterHubサインインフォームとOAuthの"Authorize"同意画面を経由するため、この処理をヘルパーモジュールに切り出した

- `結合試験-実行.ipynb` への組み込み:
  - JupyterHubのユーザ情報パラメータ `jupyterhub_username` と `jupyterhub_password` を追加
  - `取りまとめ-local-BinderHubアドオン.ipynb`を実行する「ローカル環境でのBinderHubアドオン関連テスト」セクションを追加
  - 上記セクションの実行を制御するフラグ: `skip_local_binderhub `を追加

## Ticket

n/a

## Custom Test Configuration
<!-- Leave empty to use default settings. Specify custom settings to test with specific versions or fixes. -->
- RDM_REPOSITORY: 
- RDM_BRANCH: 
- RDM_MERGE:
<!-- RDM_MERGE: Set to false to test against the custom branch without merging -->
- OSF_IMAGE: 
- EMBER_IMAGE: 
- CAS_IMAGE: 
- MFR_IMAGE: 
- WB_IMAGE:
- EXCLUDE_NOTEBOOKS: 
<!-- EXCLUDE_NOTEBOOKS: Comma-separated list of notebooks to exclude from tests -->