### PR TITLE
[GRDM-59575 Workaround] BinderHubアドオン repo2docker テストに remotes を追加

### DIFF
--- a/テスト手順-BinderHub-BinderHubアドオン-repo2docker.ipynb
+++ b/テスト手順-BinderHub-BinderHubアドオン-repo2docker.ipynb
@@ -29,10 +29,10 @@
     "binderhub_apt_package = 'sl'\n",
     "binderhub_conda_package = 'awscli'\n",
     "binderhub_pip_package = 'papermill'\n",
-    "binderhub_r_package = 'eegkit'\n",
+    "binderhub_r_packages = ['remotes', 'eegkit']\n",
     "\n",
     "binderhub_post_build_script = '''#!/bin/bash\n",
-    "date > ~/uptime'''\n",
+    "date \u003e ~/uptime'''\n",
     "binderhub_binder_files = ['apt.txt', 'environment.yml', 'install.R', 'postBuild']\n",
     "binderhub_launch_timeout = 30 * 60 * 1000   # 30 minutes\n",
     "binderhub_test_filename = 'grdm_test_file.txt'\n",
@@ -449,9 +449,9 @@
    "id": "40988528",
    "metadata": {},
    "source": [
-    "## 「R (CRAN)」の「+追加」をクリックし、パッケージを登録する\n",
+    "## 「R (CRAN)」の「+追加」をクリックし、各パッケージを登録する\n",
     "\n",
-    "パッケージ名がR (CRAN)に表示されること"
+    "登録したパッケージ名がR (CRAN)に表示されること"
    ]
   },
   {
@@ -462,13 +462,14 @@
    "outputs": [],
    "source": [
     "async def _step(page):\n",
-    "    await page.locator('//div[@data-test-package-editor = \"rmran\"]//*[@data-test-package-add]').click()\n",
-    "    field = page.locator('//input[@name = \"package_name\"]')\n",
-    "    await expect(field).to_be_visible(timeout=transition_timeout)\n",
-    "    await field.fill(binderhub_r_package)\n",
-    "    await page.locator('//button[@data-test-package-item-confirm]').click()\n",
-    "    await expect(page.locator(f'//div[@data-test-package-editor = \"rmran\"]//*[text() = \"{binderhub_r_package}\"]')).to_be_visible(timeout=transition_timeout)\n",
-    "    await asyncio.sleep(transition_timeout / 1000)\n",
+    "    for pkg in binderhub_r_packages:\n",
+    "        await page.locator('//div[@data-test-package-editor = \"rmran\"]//*[@data-test-package-add]').click()\n",
+    "        field = page.locator('//input[@name = \"package_name\"]')\n",
+    "        await expect(field).to_be_visible(timeout=transition_timeout)\n",
+    "        await field.fill(pkg)\n",
+    "        await page.locator('//button[@data-test-package-item-confirm]').click()\n",
+    "        await expect(page.locator(f'//div[@data-test-package-editor = \"rmran\"]//*[text() = \"{pkg}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "        await asyncio.sleep(transition_timeout / 1000)\n",
     "\n",
     "await run_pw(_step)"
    ]

--- a/テスト手順-BinderHub-BinderHubアドオン-アドオン追加.ipynb
+++ b/テスト手順-BinderHub-BinderHubアドオン-アドオン追加.ipynb
@@ -27,8 +27,11 @@
     "\n",
     "project_name = None\n",
     "\n",
+    "binderhub_r_packages = ['remotes']\n",
+    "\n",
     "# Use Firefox for popup handling (Chromium has issues with popup events)\n",
-    "browser_type = 'firefox'\n"
+    "browser_type = 'firefox'\n",
+    ""
    ]
   },
   {
@@ -322,6 +325,46 @@
     "\n",
     "await run_pw(_step)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lc_cell_meme": {
+     "current": "ee6fe412-5896-11f1-9ade-faebbd0a01f1",
+     "next": "f310a6fa-5896-11f1-8aa8-faebbd0a01f1",
+     "previous": null
+    }
+   },
+   "source": [
+    "## 「R (CRAN)」の「+追加」をクリックし、各パッケージを登録する\n",
+    "\n",
+    "登録したパッケージ名がR (CRAN)に表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "lc_cell_meme": {
+     "current": "f310a6fa-5896-11f1-8aa8-faebbd0a01f1",
+     "next": null,
+     "previous": "ee6fe412-5896-11f1-9ade-faebbd0a01f1"
+    }
+   },
+   "source": [
+    "async def _step(page):\n",
+    "    for pkg in binderhub_r_packages:\n",
+    "        await page.locator('//div[@data-test-package-editor = \"rmran\"]//*[@data-test-package-add]').click()\n",
+    "        field = page.locator('//input[@name = \"package_name\"]')\n",
+    "        await expect(field).to_be_visible(timeout=transition_timeout)\n",
+    "        await field.fill(pkg)\n",
+    "        await page.locator('//button[@data-test-package-item-confirm]').click()\n",
+    "        await expect(page.locator(f'//div[@data-test-package-editor = \"rmran\"]//*[text() = \"{pkg}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "        await asyncio.sleep(transition_timeout / 1000)\n",
+    "\n",
+    "await run_pw(_step)"
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",

--- a/テスト手順-BinderHubアドオン-repo2docker.ipynb
+++ b/テスト手順-BinderHubアドオン-repo2docker.ipynb
@@ -31,13 +31,14 @@
     "binderhub_apt_package = 'sl'\n",
     "binderhub_conda_package = 'awscli'\n",
     "binderhub_pip_package = 'papermill'\n",
-    "binderhub_r_package = 'eegkit'\n",
+    "binderhub_r_packages = ['remotes', 'eegkit']\n",
     "binderhub_post_build_script = '''#!/bin/bash\n",
-    "date > ~/uptime'''\n",
+    "date \u003e ~/uptime'''\n",
     "binderhub_binder_files = ['apt.txt', 'environment.yml', 'install.R', 'postBuild']\n",
     "binderhub_launch_timeout = 1800000  # 30 minutes\n",
     "binderhub_test_filename = 'grdm_test_file.txt'\n",
-    "binderhub_test_file_content = 'GRDM_FILE_SYNC_TEST'\n"
+    "binderhub_test_file_content = 'GRDM_FILE_SYNC_TEST'\n",
+    ""
    ]
   },
   {
@@ -324,9 +325,9 @@
    "id": "40988528",
    "metadata": {},
    "source": [
-    "## 「R (MRAN)」の「+追加」をクリックし、パッケージを登録する\n",
+    "## 「R (MRAN)」の「+追加」をクリックし、各パッケージを登録する\n",
     "\n",
-    "パッケージ名がR (MRAN)に表示されること"
+    "登録したパッケージ名がR (MRAN)に表示されること"
    ]
   },
   {
@@ -335,7 +336,19 @@
    "id": "84d1c03a",
    "metadata": {},
    "outputs": [],
-   "source": "async def _step(page):\n    await page.locator('//div[@data-test-package-editor = \"rmran\"]//*[@data-test-package-add]').click()\n    field = page.locator('//input[@name = \"package_name\"]')\n    await expect(field).to_be_visible(timeout=transition_timeout)\n    await field.fill(binderhub_r_package)\n    await page.locator('//button[@data-test-package-item-confirm]').click()\n    await expect(page.locator(f'//div[@data-test-package-editor = \"rmran\"]//*[text() = \"{binderhub_r_package}\"]')).to_be_visible(timeout=transition_timeout)\n    await asyncio.sleep(10)\n\nawait run_pw(_step)"
+   "source": [
+    "async def _step(page):\n",
+    "    for pkg in binderhub_r_packages:\n",
+    "        await page.locator('//div[@data-test-package-editor = \"rmran\"]//*[@data-test-package-add]').click()\n",
+    "        field = page.locator('//input[@name = \"package_name\"]')\n",
+    "        await expect(field).to_be_visible(timeout=transition_timeout)\n",
+    "        await field.fill(pkg)\n",
+    "        await page.locator('//button[@data-test-package-item-confirm]').click()\n",
+    "        await expect(page.locator(f'//div[@data-test-package-editor = \"rmran\"]//*[text() = \"{pkg}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "        await asyncio.sleep(10)\n",
+    "\n",
+    "await run_pw(_step)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/テスト手順-BinderHubアドオン-アドオン追加.ipynb
+++ b/テスト手順-BinderHubアドオン-アドオン追加.ipynb
@@ -28,8 +28,11 @@
     "\n",
     "project_name = None\n",
     "\n",
+    "binderhub_r_packages = ['remotes']\n",
+    "\n",
     "# Use Firefox for popup handling (Chromium has issues with popup events)\n",
-    "browser_type = 'firefox'\n"
+    "browser_type = 'firefox'\n",
+    ""
    ]
   },
   {
@@ -378,6 +381,46 @@
     "\n",
     "await run_pw(_step)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lc_cell_meme": {
+     "current": "aba49b44-5893-11f1-9a45-faebbd0a01f1",
+     "next": "afe69acc-5893-11f1-9313-faebbd0a01f1",
+     "previous": null
+    }
+   },
+   "source": [
+    "## 「R (MRAN)」の「+追加」をクリックし、各パッケージを登録する\n",
+    "\n",
+    "登録したパッケージ名がR (MRAN)に表示されること"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "lc_cell_meme": {
+     "current": "afe69acc-5893-11f1-9313-faebbd0a01f1",
+     "next": null,
+     "previous": "aba49b44-5893-11f1-9a45-faebbd0a01f1"
+    }
+   },
+   "source": [
+    "async def _step(page):\n",
+    "    for pkg in binderhub_r_packages:\n",
+    "        await page.locator('//div[@data-test-package-editor = \"rmran\"]//*[@data-test-package-add]').click()\n",
+    "        field = page.locator('//input[@name = \"package_name\"]')\n",
+    "        await expect(field).to_be_visible(timeout=transition_timeout)\n",
+    "        await field.fill(pkg)\n",
+    "        await page.locator('//button[@data-test-package-item-confirm]').click()\n",
+    "        await expect(page.locator(f'//div[@data-test-package-editor = \"rmran\"]//*[text() = \"{pkg}\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "        await asyncio.sleep(10)\n",
+    "\n",
+    "await run_pw(_step)"
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Purpose

`テスト手順-BinderHubアドオン-repo2docker.ipynb` / `テスト手順-BinderHub-BinderHubアドオン-repo2docker.ipynb` / `テスト手順-BinderHubアドオン-アドオン追加.ipynb` で、解析環境ビルド時に `remotes` パッケージを事前に R 依存として登録しないとビルドに失敗するケースがある。各テスト手順で R パッケージを事前登録できるようにし、デフォルトに `remotes` を含める。

## Changes

- `テスト手順-BinderHubアドオン-repo2docker.ipynb` および `テスト手順-BinderHub-BinderHubアドオン-repo2docker.ipynb`
  - パラメータ `binderhub_r_package`（単一文字列）を `binderhub_r_packages`（リスト）にリネームし、デフォルト値を `['remotes', 'eegkit']` に変更
  - R (MRAN/CRAN) 追加ステップのコードを `for pkg in binderhub_r_packages:` ループに変更し、リスト内の各パッケージを順に登録するように修正
  - 対応する Markdown 見出し・期待結果を「各パッケージを登録する／登録したパッケージ名が R (MRAN/CRAN) に表示されること」に変更し、コード実装と整合させた
- `テスト手順-BinderHubアドオン-アドオン追加.ipynb`
  - パラメータに `binderhub_r_packages = ['remotes']` を追加
  - 「解析」タブクリックと「新しい解析環境を作成」クリックの間に、R (MRAN) +追加 ループステップを挿入し、解析環境作成前に `remotes` を登録するように修正

## Ticket

## Custom Test Configuration
<!-- Leave empty to use default settings. Specify custom settings to test with specific versions or fixes. -->
- RDM_REPOSITORY:
- RDM_BRANCH:
- RDM_MERGE:
<!-- RDM_MERGE: Set to false to test against the custom branch without merging -->
- OSF_IMAGE:
- EMBER_IMAGE:
- CAS_IMAGE:
- MFR_IMAGE:
- WB_IMAGE:
- EXCLUDE_NOTEBOOKS: