### PR TITLE
[GRDM-62502] E2Eテストのエラー改善

### DIFF
--- a/scripts/grdm.py
+++ b/scripts/grdm.py
@@ -371,26 +371,39 @@ async def drop_file(page, element_locator, path):
 async def drag_and_drop(page, source, dest):
     await expect(source).to_have_class(re.compile('.*ui-draggable.*'))
 
-    center_coordinates_source = await source.evaluate('''element => {
-        const rect = element.getBoundingClientRect();
-        return {
-            x: rect.left + rect.width / 2,
-            y: rect.top + rect.height / 2
-        };
-    }''')
+    # ドロップ先→ソースの順で可視化し、両方がビューポート内にあることを保証する
+    await dest.scroll_into_view_if_needed()
+    await source.scroll_into_view_if_needed()
+    await expect(dest).to_be_in_viewport()
+    await expect(source).to_be_in_viewport()
 
-    center_coordinates_dest = await dest.evaluate('''element => {
-        const rect = element.getBoundingClientRect();
-        return {
-            x: rect.left + rect.width / 2,
-            y: rect.top + rect.height / 2
-        };
-    }''')
+    async def centers():
+        result = []
+        for locator in (source, dest):
+            result.append(await locator.evaluate('''element => {
+                const rect = element.getBoundingClientRect();
+                return [rect.left + rect.width / 2, rect.top + rect.height / 2];
+            }'''))
+        return result
 
-    await page.mouse.move(center_coordinates_source['x'], center_coordinates_source['y'])
+    # jQuery UIはドラッグ開始時にドロップ先の位置をキャッシュするため、開始前に
+    # レイアウトが静止していること(バナー出現や再描画の途中でないこと)を確認する
+    previous = await centers()
+    for _ in range(25):
+        await page.wait_for_timeout(200)
+        current = await centers()
+        if current == previous:
+            break
+        previous = current
+    else:
+        raise AssertionError(f'layout did not settle before drag and drop: {current}')
+
+    (source_x, source_y), (dest_x, dest_y) = current
+
+    await page.mouse.move(source_x, source_y)
     await page.mouse.down()
     await page.wait_for_timeout(1000)
-    await page.mouse.move(center_coordinates_dest['x'], center_coordinates_dest['y'], steps=30)
+    await page.mouse.move(dest_x, dest_y, steps=30)
     await page.wait_for_timeout(1000)
     await page.mouse.up()
 

--- a/scripts/grdm.py
+++ b/scripts/grdm.py
@@ -210,10 +210,11 @@ async def expect_dashboard(page, transition_timeout=30000, retries=3):
             # 1分待って再チャレンジ
             await asyncio.sleep(60)            
     
-async def ensure_project_exists(page, project_name, transition_timeout=30000):
+async def ensure_project_exists(page, project_name, transition_timeout=30000, existence_timeout=10000):
     await expect(page.locator('//*[@data-test-create-project-modal-button]')).to_have_count(1, timeout=transition_timeout)
     try:
-        await expect(page.locator(f'//*[@data-test-dashboard-item-title and text()="{project_name}"]')).to_be_visible()
+        # 不存在(タイムアウト)が作成フローへの正常分岐のため、既定の長いexpectタイムアウトを使わない
+        await expect(page.locator(f'//*[@data-test-dashboard-item-title and text()="{project_name}"]')).to_be_visible(timeout=existence_timeout)
         return False
     except:
         # プロジェクトが存在しない

--- a/scripts/playwright.py
+++ b/scripts/playwright.py
@@ -134,6 +134,9 @@ async def init_pw_context(close_on_fail=True, last_path=None, browser_type='chro
         await playwright.stop()
         playwright = None
     playwright = await async_playwright().start()
+    # timeout未指定のexpectはライブラリ既定の5秒に落ちてタイミング起因の失敗源になる
+    # ため、既定を transition_timeout の慣行値へ引き上げる (明示指定は影響を受けない)
+    expect.set_options(timeout=60000)
     current_session_id = datetime.now().strftime('%Y%m%d-%H%M%S')
     default_last_path = last_path or os.path.join(os.path.expanduser('~/last-screenshots'), current_session_id)
     temp_dir = tempfile.mkdtemp()

--- a/テスト手順-Workflowアドオン-公開範囲の設定.ipynb
+++ b/テスト手順-Workflowアドオン-公開範囲の設定.ipynb
@@ -621,7 +621,10 @@
    "id": "837d6c63",
    "metadata": {},
    "source": [
-    "## テンプレート管理プロジェクトのURLを開き、テンプレート登録者でログインする"
+    "## テンプレート管理プロジェクトのURLを開き、テンプレート登録者でログインする\n",
+    "\n",
+    "プロジェクトページが表示されること\n",
+    ""
    ]
   },
   {
@@ -634,8 +637,10 @@
     "async def _step(page):\n",
     "    await page.goto(template_project_url)\n",
     "    await grdm.login(page, idp_name_registrar, idp_username_registrar, idp_password_registrar, transition_timeout=transition_timeout)\n",
+    "    await expect(page.locator('//span[@id = \"nodeTitleEditable\"]')).to_be_visible(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {

--- a/テスト手順-Workflowアドオン-有効化・無効化.ipynb
+++ b/テスト手順-Workflowアドオン-有効化・無効化.ipynb
@@ -205,10 +205,12 @@
     "async def _step(page):\n",
     "    await page.locator('//a[text() = \"アドオン\"]').click()\n",
     "    await expect(page.locator('//h3[text() = \"アドオンを選択\"]')).to_be_visible(timeout=transition_timeout)\n",
-    "    await page.locator('#activationsPanel').locator('//button[*[text() = \"無効にする\"]]').scroll_into_view_if_needed()\n",
-    "    await expect(page.locator('#activationsPanel').locator('//button[*[text() = \"無効にする\"]]')).to_be_enabled(timeout=transition_timeout)\n",
+    "    row = page.locator('#activationsPanel').locator(f'//tr[.//strong[text()=\"{workflow_name}\"]]')\n",
+    "    await row.locator('//button[*[text() = \"無効にする\"]]').scroll_into_view_if_needed()\n",
+    "    await expect(row.locator('//button[*[text() = \"無効にする\"]]')).to_be_enabled(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {
@@ -229,10 +231,12 @@
    "outputs": [],
    "source": [
     "async def _step(page):\n",
-    "    await page.locator('#activationsPanel').locator('//button[*[text() = \"無効にする\"]]').click()\n",
+    "    row = page.locator('#activationsPanel').locator(f'//tr[.//strong[text()=\"{workflow_name}\"]]')\n",
+    "    await row.locator('//button[*[text() = \"無効にする\"]]').click()\n",
     "    await expect(page.locator('//h4[text() = \"ワークフローの無効化\"]')).to_be_visible(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {
@@ -455,10 +459,12 @@
     "async def _step(page):\n",
     "    await page.locator('//a[text() = \"アドオン\"]').click()\n",
     "    await expect(page.locator('//h3[text() = \"アドオンを選択\"]')).to_be_visible(timeout=transition_timeout)\n",
-    "    await page.locator('#activationsPanel').locator('//button[*[text() = \"無効にする\"]]').scroll_into_view_if_needed()\n",
-    "    await expect(page.locator('#activationsPanel').locator('//button[*[text() = \"無効にする\"]]')).to_be_enabled(timeout=transition_timeout)\n",
+    "    row = page.locator('#activationsPanel').locator(f'//tr[.//strong[text()=\"{workflow_name}\"]]')\n",
+    "    await row.locator('//button[*[text() = \"無効にする\"]]').scroll_into_view_if_needed()\n",
+    "    await expect(row.locator('//button[*[text() = \"無効にする\"]]')).to_be_enabled(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {
@@ -478,12 +484,14 @@
    "outputs": [],
    "source": [
     "async def _step(page):\n",
-    "    await page.locator('#activationsPanel').locator('//button[*[text() = \"無効にする\"]]').click()\n",
+    "    row = page.locator('#activationsPanel').locator(f'//tr[.//strong[text()=\"{workflow_name}\"]]')\n",
+    "    await row.locator('//button[*[text() = \"無効にする\"]]').click()\n",
     "    await expect(page.locator('//h4[text() = \"ワークフローの無効化\"]')).to_be_visible(timeout=transition_timeout)\n",
     "    await page.locator('//button[contains(@data-bind, \"confirmDisableActivation\")]').click()\n",
-    "    await expect(page.locator('#activationsPanel').locator('//*[contains(@class, \"label\") and text() = \"無効\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(row.locator('//*[contains(@class, \"label\") and text() = \"無効\"]')).to_be_visible(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {
@@ -775,10 +783,12 @@
     "async def _step(page):\n",
     "    await page.locator('//a[text() = \"アドオン\"]').click()\n",
     "    await expect(page.locator('//h3[text() = \"アドオンを選択\"]')).to_be_visible(timeout=transition_timeout)\n",
-    "    await page.locator('#localWorkflowsPanel').locator('//button[*[text() = \"無効にする\"]]').scroll_into_view_if_needed()\n",
-    "    await expect(page.locator('#localWorkflowsPanel').locator('//button[*[text() = \"無効にする\"]]')).to_be_enabled(timeout=transition_timeout)\n",
+    "    row = page.locator('#localWorkflowsPanel').locator(f'//tr[.//strong[text()=\"{workflow_name}\"]]')\n",
+    "    await row.locator('//button[*[text() = \"無効にする\"]]').scroll_into_view_if_needed()\n",
+    "    await expect(row.locator('//button[*[text() = \"無効にする\"]]')).to_be_enabled(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {
@@ -799,10 +809,12 @@
    "outputs": [],
    "source": [
     "async def _step(page):\n",
-    "    await page.locator('#localWorkflowsPanel').locator('//button[*[text() = \"無効にする\"]]').click()\n",
+    "    row = page.locator('#localWorkflowsPanel').locator(f'//tr[.//strong[text()=\"{workflow_name}\"]]')\n",
+    "    await row.locator('//button[*[text() = \"無効にする\"]]').click()\n",
     "    await expect(page.locator('//h4[text() = \"ワークフローテンプレートの無効化\"]')).to_be_visible(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {
@@ -916,13 +928,15 @@
    "outputs": [],
    "source": [
     "async def _step(page):\n",
-    "    await page.locator('#localWorkflowsPanel').locator('//button[*[text() = \"無効にする\"]]').scroll_into_view_if_needed()\n",
-    "    await page.locator('#localWorkflowsPanel').locator('//button[*[text() = \"無効にする\"]]').click()\n",
+    "    row = page.locator('#localWorkflowsPanel').locator(f'//tr[.//strong[text()=\"{workflow_name}\"]]')\n",
+    "    await row.locator('//button[*[text() = \"無効にする\"]]').scroll_into_view_if_needed()\n",
+    "    await row.locator('//button[*[text() = \"無効にする\"]]').click()\n",
     "    await expect(page.locator('//h4[text() = \"ワークフローテンプレートの無効化\"]')).to_be_visible(timeout=transition_timeout)\n",
     "    await page.locator('//button[contains(@data-bind, \"confirmDisableTemplate\")]').click()\n",
-    "    await expect(page.locator('#localWorkflowsPanel').locator('//*[contains(@class, \"label\") and text() = \"無効\"]')).to_be_visible(timeout=transition_timeout)\n",
+    "    await expect(row.locator('//*[contains(@class, \"label\") and text() = \"無効\"]')).to_be_visible(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {

--- a/テスト手順-Workflowアドオン-自動有効化.ipynb
+++ b/テスト手順-Workflowアドオン-自動有効化.ipynb
@@ -654,7 +654,10 @@
    "id": "2816ee79",
    "metadata": {},
    "source": [
-    "## テンプレート管理プロジェクトのURLを開き、テンプレート登録者でログインする"
+    "## テンプレート管理プロジェクトのURLを開き、テンプレート登録者でログインする\n",
+    "\n",
+    "プロジェクトページが表示されること\n",
+    ""
    ]
   },
   {
@@ -667,8 +670,10 @@
     "async def _step(page):\n",
     "    await page.goto(template_project_url)\n",
     "    await grdm.login(page, idp_name_registrar, idp_username_registrar, idp_password_registrar, transition_timeout=transition_timeout)\n",
+    "    await expect(page.locator('//span[@id = \"nodeTitleEditable\"]')).to_be_visible(timeout=transition_timeout)\n",
     "\n",
-    "await run_pw(_step)"
+    "await run_pw(_step)\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Purpose

**問題1: 再ログインステップ直後のスクリーンショットが確率的に失敗する**

Workflowアドオンの E2E（自動有効化 / 公開範囲の設定 の institution 変種）で、「テンプレート管理プロジェクトのURLを開き、テンプレート登録者でログインする」ステップ直後のスクリーンショットが `Page.screenshot: Protocol error (Page.captureScreenshot): Unable to capture screenshot` で失敗することがあります（https://github.com/RCOSDP/RDM-e2e-test-nb/actions/runs/32126230244 の attempt 1/2 双方で発生。rdm=develop 構成の run でも同一シグネチャを確認）。

原因は、このステップが `grdm.login`（FakeCAS 経路は submit クリック後に何も待たずに戻る）の直後に終わるため、run_pw のステップ後スクリーンショットが FakeCAS → CAS → RDM のクロスオリジンリダイレクト連鎖と競合することです。Chromium はクロスオリジン遷移でレンダラプロセスを交換するため、描画面が存在しない瞬間に `Page.captureScreenshot` が当たるとこのエラーになります。序盤のログインステップは `expect_dashboard` で着地を待っているため発生せず、待ちの無いこのステップだけで発生します。

**問題2: 「無効にする」ボタンのロケータが行スコープなしで、テンプレートが2つあると strict mode violation になる**

有効化・無効化 NB は `#localWorkflowsPanel`/`#activationsPanel` 直下の「無効にする」ボタンを行スコープなしで参照しています。同じテンプレート管理プロジェクトを共有する先行 NB が（問題1などで）失敗して後始末が走らずテンプレートが残ると、ボタンが2要素に一致して strict mode violation になります（失敗のカスケード）。

**問題3: timeout未指定の expect がライブラリ既定の5秒に落ちて失敗源になる**

assertion 全 3160 箇所のうち 199 箇所（38 ノートブック）が timeout 未指定で、Playwright の expect 既定 5000ms で動いています。`transition_timeout`（慣行値 60 秒）で外部制御する設計の潰し忘れで、環境が遅い leg では恒常的な失敗になります（例: ファイル基本操作の「名前を変更」メニュー待ちが NII Storage leg で 5 秒超過、本PRのCIでも再現）。意図的に短く待つ箇所はすべて明示引数（500/1000/2000ms）で書かれており、未指定箇所だけが既定値に依存しています。

**問題4: ファイル移動などのドラッグ&ドロップが、レイアウト変動で無音で不発になる**

S3 系 leg で「移動に成功しました」トーストが 60〜300 秒待っても出ない失敗が反復していました。サーバログ（WaterButler / MinIO）を突き合わせたところ、**move リクエスト自体がブラウザから発行されておらず**、失敗時の DOM には利用規約の同意バナー（`accepted_terms_of_service` 未設定ユーザーにページ描画のたびに挿入されるジャンボトロン）が出現してページ全体を押し下げていました。`grdm.drag_and_drop` は事前に取得した座標へマウス操作するだけなので、座標取得とドロップの間にレイアウトが動くと何にも当たらず、エラーも出ません。

## Changes

- 自動有効化 / 公開範囲の設定: 再ログインステップに、ログイン後のプロジェクトページ表示を確認する expect を追加（序盤のログインステップと同じ流儀）
- 有効化・無効化: 「無効にする」を参照する 7 セルを、他 NB と同じ `workflow_name` の行スコープ（`//tr[.//strong[text()="{workflow_name}"]]`）に変更
- scripts/grdm.py: `drag_and_drop` を強化。ドロップ先とソースを scroll_into_view してビューポート内にあることを確認し、双方の座標が連続する 2 回の測定で一致する（レイアウトが静止している）まで待ってからマウス操作を開始する。静止しない場合は無音で外す代わりに明示的に失敗する。jQuery UI はドラッグ開始時にドロップ先位置をキャッシュするため、ドラッグ中の座標補正ではなく開始前の静止確認を不変条件とした
- scripts/playwright.py: `init_pw_context` で `expect.set_options(timeout=60000)` を設定し、timeout 未指定の expect の既定を transition_timeout の慣行値に引き上げ。明示指定（短いプローブ含む）には影響しない。ノートブック側の編集は不要で、以後 timeout の書き忘れ自体が安全になる

## Ticket

GRDM-62502

## Custom Test Configuration

Migration レグは develop の migration 不具合（`osf.0267_split_name_fields` が現行モデルの副作用を実行するため、後から追加された `osf_osfuser.ial` 列の参照で 20250906 からのアップグレードが失敗する）に当たるため、修正ブランチ（yacchin1205/RDM2-osf.io fix/migration-historical-models）を指定して検証します。RDM-osf.io 側へ同修正の PR を提出予定です。

- RDM_REPOSITORY: yacchin1205/RDM2-osf.io
- RDM_BRANCH: fix/migration-historical-models
- RDM_MERGE:
